### PR TITLE
Introduce AI desire profiles

### DIFF
--- a/forge-ai/src/main/java/forge/ai/AiAttackController.java
+++ b/forge-ai/src/main/java/forge/ai/AiAttackController.java
@@ -31,6 +31,9 @@ import forge.game.combat.GlobalAttackRestrictions;
 import forge.game.cost.Cost;
 import forge.game.keyword.Keyword;
 import forge.game.keyword.KeywordInterface;
+import forge.ai.AiDesireState;
+import forge.ai.AiDesireProfile;
+import forge.ai.PlayerControllerAi;
 import forge.game.player.Player;
 import forge.game.player.PlayerCollection;
 import forge.game.spellability.SpellAbility;
@@ -845,6 +848,14 @@ public class AiAttackController {
 
         final boolean bAssault = doAssault();
 
+        AiDesireState desireState = null;
+        if (ai.getController() instanceof PlayerControllerAi) {
+            desireState = ((PlayerControllerAi) ai.getController()).getAi().getDesireState();
+            if (desireState != null && desireState.get(AiDesireProfile.Action.ATTACK_WITH_BIG_CREATURE) > 0) {
+                aiAggression = Math.max(aiAggression, 4);
+            }
+        }
+
         // Determine who will be attacked
         GameEntity defender = chooseDefender(combat, bAssault);
 
@@ -1352,6 +1363,9 @@ public class AiAttackController {
             }
         }
 
+        if (desireState != null && !combat.getAttackers().isEmpty()) {
+            desireState.consume(AiDesireProfile.Action.ATTACK_WITH_BIG_CREATURE);
+        }
         return aiAggression;
     }
 

--- a/forge-ai/src/main/java/forge/ai/AiDesireProfile.java
+++ b/forge-ai/src/main/java/forge/ai/AiDesireProfile.java
@@ -1,0 +1,66 @@
+package forge.ai;
+
+import forge.util.FileUtil;
+import forge.util.TextUtil;
+
+import java.io.File;
+import java.util.*;
+
+/**
+ * Holds static desire multipliers for various actions.
+ */
+public class AiDesireProfile {
+    public enum Action { PLAY_MANA_SOURCE, ATTACK_WITH_BIG_CREATURE }
+
+    private final Map<Action, Double> multipliers = new EnumMap<>(Action.class);
+
+    private static String PROFILE_DIR;
+    private static final String EXT = ".desire";
+    private static final Map<String, AiDesireProfile> LOADED = new HashMap<>();
+
+    public double getMultiplier(Action a) {
+        return multipliers.getOrDefault(a, 1.0);
+    }
+
+    private static String buildFileName(String name) {
+        return TextUtil.concatNoSpace(PROFILE_DIR, File.separator, name, EXT);
+    }
+
+    private static AiDesireProfile loadProfile(String name) {
+        AiDesireProfile prof = new AiDesireProfile();
+        List<String> lines = FileUtil.readFile(buildFileName(name));
+        for (String line : lines) {
+            if (line.startsWith("#") || line.trim().isEmpty()) {
+                continue;
+            }
+            String[] sp = line.split("=");
+            if (sp.length == 2) {
+                try {
+                    Action a = Action.valueOf(sp[0].trim());
+                    double v = Double.parseDouble(sp[1].trim());
+                    prof.multipliers.put(a, v);
+                } catch (Exception ignored) {
+                }
+            }
+        }
+        return prof;
+    }
+
+    public static void loadAllProfiles(String dir) {
+        PROFILE_DIR = dir;
+        LOADED.clear();
+        File d = new File(dir);
+        String[] children = d.list();
+        if (children == null) { return; }
+        for (String c : children) {
+            if (c.endsWith(EXT)) {
+                String name = c.substring(0, c.length() - EXT.length());
+                LOADED.put(name, loadProfile(name));
+            }
+        }
+    }
+
+    public static AiDesireProfile getProfile(String name) {
+        return LOADED.get(name);
+    }
+}

--- a/forge-ai/src/main/java/forge/ai/AiDesireState.java
+++ b/forge-ai/src/main/java/forge/ai/AiDesireState.java
@@ -1,0 +1,32 @@
+package forge.ai;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+/**
+ * Tracks accumulated desire scores for the AI.
+ */
+public class AiDesireState {
+    private final AiDesireProfile profile;
+    private final Map<AiDesireProfile.Action, Double> values = new EnumMap<>(AiDesireProfile.Action.class);
+
+    public AiDesireState(AiDesireProfile profile) {
+        this.profile = profile;
+    }
+
+    public void newTurn() {
+        for (AiDesireProfile.Action a : AiDesireProfile.Action.values()) {
+            double inc = profile.getMultiplier(a);
+            values.merge(a, inc, Double::sum);
+        }
+    }
+
+    public void consume(AiDesireProfile.Action a) {
+        double inc = profile.getMultiplier(a);
+        values.merge(a, -inc, Double::sum);
+    }
+
+    public double get(AiDesireProfile.Action a) {
+        return values.getOrDefault(a, 0.0);
+    }
+}

--- a/forge-ai/src/main/java/forge/ai/PlayerControllerAi.java
+++ b/forge-ai/src/main/java/forge/ai/PlayerControllerAi.java
@@ -65,6 +65,7 @@ public class PlayerControllerAi extends PlayerController {
         super(game, p, lp);
 
         brains = new AiController(p, game);
+        game.subscribeToEvents(brains);
     }
 
     public boolean pilotsNonAggroDeck() {
@@ -73,6 +74,10 @@ public class PlayerControllerAi extends PlayerController {
 
     public void setupAutoProfile(Deck deck) {
         pilotsNonAggroDeck = deck.getName().contains("Control") || Deck.getAverageCMC(deck) > 3;
+        String desire = deck.getAiDesireProfile();
+        if (desire != null && !desire.isEmpty()) {
+            brains.setDesireProfile(AiDesireProfile.getProfile(desire));
+        }
     }
 
     public void allowCheatShuffle(boolean value) {

--- a/forge-core/src/main/java/forge/deck/Deck.java
+++ b/forge-core/src/main/java/forge/deck/Deck.java
@@ -47,6 +47,7 @@ public class Deck extends DeckBase implements Iterable<Entry<DeckSection, CardPo
     // Supports deferring loading a deck until we actually need its contents. This works in conjunction with
     // the lazy card load feature to ensure we don't need to load all cards on start up.
     private final Set<String> aiHints = new TreeSet<>();
+    private String aiDesireProfile = null;
     private final Map<String, String> draftNotes = new HashMap<>();
     private Map<String, List<String>> deferredSections = null;
     private Map<String, List<String>> loadedSections = null;
@@ -214,6 +215,7 @@ public class Deck extends DeckBase implements Iterable<Entry<DeckSection, CardPo
             cp.addAll(kv.getValue());
         }
         result.setAiHints(StringUtils.join(aiHints, " | "));
+        result.setAiDesireProfile(aiDesireProfile);
         result.setDraftNotes(draftNotes);
         tags.addAll(result.getTags());
     }
@@ -542,6 +544,14 @@ public class Deck extends DeckBase implements Iterable<Entry<DeckSection, CardPo
             }
         }
         return "";
+    }
+
+    public void setAiDesireProfile(String profile) {
+        this.aiDesireProfile = profile == null ? null : profile.trim();
+    }
+
+    public String getAiDesireProfile() {
+        return aiDesireProfile == null ? "" : aiDesireProfile;
     }
 
     public void setDraftNotes(Map<String, String> draftNotes) {

--- a/forge-core/src/main/java/forge/deck/io/DeckFileHeader.java
+++ b/forge-core/src/main/java/forge/deck/io/DeckFileHeader.java
@@ -47,6 +47,7 @@ public class DeckFileHeader {
     private static final String CSTM_POOL = "Custom Pool";
     private static final String PLAYER_TYPE = "PlayerType";
     public static final String AI_HINTS = "AiHints";
+    public static final String AI_DESIRE_PROFILE = "AiDesireProfile";
 
     private final DeckFormat deckType;
     private final boolean customPool;
@@ -59,6 +60,7 @@ public class DeckFileHeader {
 
     private final boolean intendedForAi;
     private final String aiHints;
+    private final String aiDesireProfile;
 
     public boolean isIntendedForAi() {
         return intendedForAi;
@@ -68,6 +70,10 @@ public class DeckFileHeader {
         return aiHints;
     }
 
+    public String getAiDesireProfile() {
+        return aiDesireProfile;
+    }
+
     public DeckFileHeader(final FileSection kvPairs) {
         this.name = kvPairs.get(DeckFileHeader.NAME);
         this.comment = kvPairs.get(DeckFileHeader.COMMENT);
@@ -75,6 +81,7 @@ public class DeckFileHeader {
         this.customPool = kvPairs.getBoolean(DeckFileHeader.CSTM_POOL);
         this.intendedForAi = "computer".equalsIgnoreCase(kvPairs.get(DeckFileHeader.PLAYER)) || "ai".equalsIgnoreCase(kvPairs.get(DeckFileHeader.PLAYER_TYPE));
         this.aiHints = kvPairs.get(DeckFileHeader.AI_HINTS);
+        this.aiDesireProfile = kvPairs.get(DeckFileHeader.AI_DESIRE_PROFILE);
 
         this.tags = new TreeSet<>();
         

--- a/forge-core/src/main/java/forge/deck/io/DeckSerializer.java
+++ b/forge-core/src/main/java/forge/deck/io/DeckSerializer.java
@@ -55,6 +55,9 @@ public class DeckSerializer {
         if (!d.getAiHints().isEmpty()) {
             out.add(TextUtil.concatNoSpace(DeckFileHeader.AI_HINTS, "=", StringUtils.join(d.getAiHints(), " | ")));
         }
+        if (!d.getAiDesireProfile().isEmpty()) {
+            out.add(TextUtil.concatNoSpace(DeckFileHeader.AI_DESIRE_PROFILE, "=", d.getAiDesireProfile()));
+        }
         if (!d.getDraftNotes().isEmpty()) {
             String sb = serializeDraftNotes(d.getDraftNotes());
             out.add(TextUtil.concatNoSpace(DeckFileHeader.DRAFT_NOTES, "=", sb));
@@ -98,6 +101,7 @@ public class DeckSerializer {
         Deck d = new Deck(dh.getName());
         d.setComment(dh.getComment());
         d.setAiHints(dh.getAiHints());
+        d.setAiDesireProfile(dh.getAiDesireProfile());
         d.getTags().addAll(dh.getTags());
         d.setDraftNotes(dh.getDraftNotes());
         d.setDeferredSections(sections);

--- a/forge-gui/res/desire/Default.desire
+++ b/forge-gui/res/desire/Default.desire
@@ -1,0 +1,3 @@
+# Basic AI desire profile
+PLAY_MANA_SOURCE=1.0
+ATTACK_WITH_BIG_CREATURE=0.5

--- a/forge-gui/src/main/java/forge/localinstance/properties/ForgeConstants.java
+++ b/forge-gui/src/main/java/forge/localinstance/properties/ForgeConstants.java
@@ -94,6 +94,7 @@ public final class ForgeConstants {
     public static final String FORMATS_DATA_DIR             = RES_DIR + "formats" + PATH_SEPARATOR;
     public static final String DECK_CUBE_DIR                = RES_DIR + "cube" + PATH_SEPARATOR;
     public static final String AI_PROFILE_DIR               = RES_DIR + "ai" + PATH_SEPARATOR;
+    public static final String AI_DESIRE_DIR                = RES_DIR + "desire" + PATH_SEPARATOR;
     public static final String SOUND_DIR                    = RES_DIR + "sound" + PATH_SEPARATOR;
     public static final String MUSIC_DIR                    = RES_DIR + "music" + PATH_SEPARATOR;
     public static final String ADVENTURE_MUSIC_DIR          = ADVENTURE_DEFAULT_PLANE_DIR + "music" + PATH_SEPARATOR;

--- a/forge-gui/src/main/java/forge/model/FModel.java
+++ b/forge-gui/src/main/java/forge/model/FModel.java
@@ -24,6 +24,7 @@ import forge.ImageKeys;
 import forge.MulliganDefs;
 import forge.StaticData;
 import forge.ai.AiProfileUtil;
+import forge.ai.AiDesireProfile;
 import forge.card.CardRulesPredicates;
 import forge.card.CardType;
 import forge.deck.CardArchetypeLDAGenerator;
@@ -269,6 +270,7 @@ public final class FModel {
 
         //preload AI profiles
         AiProfileUtil.loadAllProfiles(ForgeConstants.AI_PROFILE_DIR);
+        AiDesireProfile.loadAllProfiles(ForgeConstants.AI_DESIRE_DIR);
         AiProfileUtil.setAiSideboardingMode(AiProfileUtil.AISideboardingMode.normalizedValueOf(FModel.getPreferences().getPref(FPref.MATCH_AI_SIDEBOARDING_MODE)));
 
         //generate Deck Gen matrix


### PR DESCRIPTION
## Summary
- add AI desire profiles with per-action multipliers
- load desire profiles from new `res/desire` folder and decks
- track desire state each turn and adjust decisions when attacking or playing lands
- wire desire profiles through deck metadata and AI controllers

## Testing
- `mvn test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6862f6a880048320b37b5bcaad2e962b