### PR TITLE
Add custom VHS card scripts

### DIFF
--- a/forge-gui/res/cardsfolder/VHS/beat_and_batter.txt
+++ b/forge-gui/res/cardsfolder/VHS/beat_and_batter.txt
@@ -1,0 +1,8 @@
+Name:Beat & Batter
+ManaCost:R
+Types:Instant
+A:SP$ Effect | StaticAbilities$ STCantGain,STCantPrevent | AILogic$ Burn | SubAbility$ DBDamage | SpellDescription$ Players can't gain life this turn. Damage can't be prevented this turn. CARDNAME deals 2 damage to target player.
+SVar:STCantGain:Mode$ CantGainLife | ValidPlayer$ Player | Description$ Players can't gain life this turn.
+SVar:STCantPrevent:Mode$ CantPreventDamage | Description$ Damage can't be prevented.
+SVar:DBDamage:DB$ DealDamage | ValidTgts$ Player | TgtPrompt$ Select target player | NumDmg$ 2 | NoPrevention$ True
+Oracle:Damage can't be prevented this turn. Players can't gain life this turn. Beat & Batter deals 2 damage to target player.

--- a/forge-gui/res/cardsfolder/VHS/bloody_valentine.txt
+++ b/forge-gui/res/cardsfolder/VHS/bloody_valentine.txt
@@ -1,0 +1,12 @@
+Name:Bloody Valentine
+ManaCost:1 R
+Types:Creature Human
+PT:2/2
+T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ Player | TriggerZones$ Battlefield | Execute$ TrigBranch | TriggerDescription$ At the beginning of each player's end step, CARDNAME deals 2 damage to that player unless they're horrific.
+SVar:TrigBranch:DB$ Branch | BranchConditionSVar$ Horrific | BranchConditionSVarCompare$ GE1 | TrueSubAbility$ DBNothing | FalseSubAbility$ DBDamage
+SVar:DBDamage:DB$ DealDamage | Defined$ TriggeredPlayer | NumDmg$ 2
+SVar:DBNothing:DB$ Nothing
+SVar:SacCount:PlayerCountPropertyTriggeredPlayer$SacrificedThisTurn Permanent
+SVar:DiscardCount:PlayerCountPropertyTriggeredPlayer$CardsDiscardedThisTurn
+SVar:Horrific:SVar$SacCount/Plus.DiscardCount
+Oracle:At the beginning of each player's end step, Bloody Valentine deals 2 damage to that player unless they're horrific. (You're horrific as long as you've sacrificed a permanent or discarded a card this turn.)

--- a/forge-gui/res/cardsfolder/VHS/catastrophic_crash.txt
+++ b/forge-gui/res/cardsfolder/VHS/catastrophic_crash.txt
@@ -1,0 +1,11 @@
+Name:Catastrophic Crash
+ManaCost:R R
+Types:Instant
+A:SP$ Charm | MinCharmNum$ 1 | CharmNum$ Count$Compare Y GE1.2.1 | Choices$ DBDestroy,DBDamage | AdditionalDescription$ If you're horrific, you may choose both instead. (You're horrific as long as you've sacrificed a permanent or discarded a card this turn.)
+SVar:DBDestroy:DB$ Destroy | ValidTgts$ Artifact | TgtPrompt$ Select target artifact | SpellDescription$ Destroy target artifact.
+SVar:DBDamage:DB$ DealDamage | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ 3 | SpellDescription$ CARDNAME deals 3 damage to target creature.
+SVar:SacCount:PlayerCountPropertyYou$SacrificedThisTurn Permanent
+SVar:DiscardCount:PlayerCountPropertyYou$CardsDiscardedThisTurn
+SVar:Horrific:SVar$SacCount/Plus.DiscardCount
+SVar:Y:SVar$Horrific
+Oracle:Choose one. If you're horrific, you may choose both instead. (You're horrific as long as you've sacrificed a permanent or discarded a card this turn.)\n• Destroy target artifact.\n• Catastrophic Crash deals 3 damage to target creature.

--- a/forge-gui/res/cardsfolder/VHS/communion.txt
+++ b/forge-gui/res/cardsfolder/VHS/communion.txt
@@ -1,0 +1,8 @@
+Name:Communion
+ManaCost:2 R
+Types:Sorcery
+A:SP$ GainControl | ValidTgts$ Creature | TgtPrompt$ Select target creature | Untap$ True | AddKWs$ Haste | LoseControl$ EOT | SubAbility$ ExileSelf | SpellDescription$ Gain control of target creature until end of turn. Untap it. It gains haste until end of turn.
+SVar:ExileSelf:DB$ ChangeZone | Origin$ Stack | Destination$ Exile | Defined$ Self | ConditionDefined$ Self | ConditionPresent$ Card.wasCast+wasCastFromHand | ConditionCompare$ EQ1
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Creature.YouCtrl | TriggerZones$ Exile | Execute$ CastRerun | TriggerDescription$ Rerun — Whenever a creature you control dies, you may cast this card from exile without paying its mana cost.
+SVar:CastRerun:DB$ Play | Defined$ Self | Amount$ 1 | Controller$ You | WithoutManaCost$ True | Optional$ True | ActivationZone$ Exile
+Oracle:Gain control of target creature until end of turn. Untap it. It gains haste until end of turn.\nRerun — Then if you cast this from your hand, exile it as it resolves. Whenever a creature you control dies, you may cast this card from exile without paying its mana cost.

--- a/forge-gui/res/cardsfolder/VHS/end_of_the_rainbow.txt
+++ b/forge-gui/res/cardsfolder/VHS/end_of_the_rainbow.txt
@@ -1,0 +1,6 @@
+Name:End of the Rainbow
+ManaCost:1 R
+Types:Sorcery
+A:SP$ Token | Cost$ Sac<1/Creature> | TokenAmount$ X | TokenScript$ c_a_treasure_sac | TokenOwner$ You | SpellDescription$ As an additional cost to cast this spell, sacrifice a creature. Create X Treasure tokens, where X is the sacrificed creature's mana value.
+SVar:X:Sacrificed$CardManaCost
+Oracle:As an additional cost to cast this spell, sacrifice a creature. Create X Treasure tokens, where X is the sacrificed creature's mana value.

--- a/forge-gui/res/cardsfolder/VHS/foreboding_presence.txt
+++ b/forge-gui/res/cardsfolder/VHS/foreboding_presence.txt
@@ -1,0 +1,11 @@
+Name:Foreboding Presence
+ManaCost:R
+Types:Enchantment
+T:Mode$ SpellCast | ValidActivatingPlayer$ Player | TriggerZones$ Battlefield | Execute$ TrigCounter | TriggerDescription$ Whenever a player casts a spell, put a doom counter on CARDNAME.
+SVar:TrigCounter:DB$ PutCounter | Defined$ Self | CounterType$ DOOM | CounterNum$ 1
+T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ Player | TriggerZones$ Battlefield | Execute$ TrigDamage | CheckSVar$ SpellsCast | SVarCompare$ EQ0 | TriggerDescription$ At the beginning of each player's end step, if no spells were cast this turn, sacrifice CARDNAME. It deals damage equal to the number of doom counters on it to that player.
+SVar:TrigDamage:DB$ DealDamage | Defined$ TriggeredPlayer | NumDmg$ X | SubAbility$ DBSac
+SVar:DBSac:DB$ Sacrifice | Defined$ Self
+SVar:X:Count$CardCounters.DOOM
+SVar:SpellsCast:PlayerCountPlayers$SpellsCastThisTurn
+Oracle:Whenever a player casts a spell, put a doom counter on Foreboding Presence.\nAt the beginning of each player's end step, if no spells were cast this turn, sacrifice Foreboding Presence. It deals damage equal to the number of doom counters on it to that player.

--- a/forge-gui/res/cardsfolder/VHS/from_within_the_dark.txt
+++ b/forge-gui/res/cardsfolder/VHS/from_within_the_dark.txt
@@ -1,0 +1,6 @@
+Name:From Within the Dark
+ManaCost:3 R
+Types:Enchantment
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Creature.YouCtrl | TriggerZones$ Battlefield | FirstTime$ True | Execute$ TrigDig | TriggerDescription$ Whenever a creature enters the battlefield under your control for the first time each turn, you may sacrifice it. If you do, exile cards from the top of your library until you exile a creature card. Put that card onto the battlefield.
+SVar:TrigDig:AB$ DigUntil | Cost$ Sac<1/Card.TriggeredCard> | Defined$ You | Valid$ Creature | ValidDescription$ creature card | FoundDestination$ Battlefield | RevealedDestination$ Exile
+Oracle:Whenever a creature enters the battlefield under your control for the first time each turn, you may sacrifice it. If you do, exile cards from the top of your library until you exile a creature card. Put that card onto the battlefield.

--- a/forge-gui/res/cardsfolder/VHS/he_of_all_hallows_eve.txt
+++ b/forge-gui/res/cardsfolder/VHS/he_of_all_hallows_eve.txt
@@ -1,0 +1,12 @@
+Name:He of All Hallow's Eve
+ManaCost:3 R R
+Types:Legendary Creature Horror
+PT:7/7
+K:Menace
+T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | TriggerZones$ Battlefield | CheckSVar$ Horrific | SVarCompare$ LE0 | Execute$ TrigDamage | TriggerDescription$ At the beginning of your end step, CARDNAME deals damage equal to its power to you unless you're horrific.
+SVar:TrigDamage:DB$ DealDamage | Defined$ You | NumDmg$ X
+SVar:X:TriggeredCard$CardPower
+SVar:SacCount:PlayerCountPropertyYou$SacrificedThisTurn Permanent
+SVar:DiscardCount:PlayerCountPropertyYou$CardsDiscardedThisTurn
+SVar:Horrific:SVar$SacCount/Plus.DiscardCount
+Oracle:Menace\nAt the beginning of your end step, He of All Hallow's Eve deals damage equal to its power to you unless you're horrific. (You're horrific as long as you've sacrificed a permanent or discarded a card this turn.)

--- a/forge-gui/res/cardsfolder/VHS/malformed_mongrel.txt
+++ b/forge-gui/res/cardsfolder/VHS/malformed_mongrel.txt
@@ -1,0 +1,8 @@
+Name:Malformed Mongrel
+ManaCost:R
+Types:Creature Hound Horror
+PT:2/2
+K:Haste
+T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | TriggerZones$ Battlefield | Execute$ TrigDiscard | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, discard a card.
+SVar:TrigDiscard:DB$ Discard | Defined$ You | NumCards$ 1 | Mode$ TgtChoose
+Oracle:Haste\nWhenever Malformed Mongrel deals combat damage to a player, discard a card.

--- a/forge-gui/res/cardsfolder/VHS/misshapen_monstrosity.txt
+++ b/forge-gui/res/cardsfolder/VHS/misshapen_monstrosity.txt
@@ -1,0 +1,8 @@
+Name:Misshapen Monstrosity
+ManaCost:2 R
+Types:Creature Horror
+PT:2/2
+S:Mode$ Continuous | Affected$ Creature.Other+YouCtrl | AddPower$ 2 | AddKeyword$ Menace | Description$ Other creatures you control get +2/+0 and have menace.
+T:Mode$ Destroyed | ValidCard$ Creature.Other+YouCtrl | TriggerZones$ Battlefield | Execute$ TrigSac | TriggerDescription$ Whenever another creature you control is destroyed, sacrifice a creature.
+SVar:TrigSac:DB$ Sacrifice | Defined$ You | SacValid$ Creature | Amount$ 1
+Oracle:Other creatures you control get +2/+0 and have menace.\nWhenever another creature you control dies, if it wasn't sacrificed, sacrifice a creature.

--- a/forge-gui/res/cardsfolder/VHS/roadside_reaper.txt
+++ b/forge-gui/res/cardsfolder/VHS/roadside_reaper.txt
@@ -1,0 +1,10 @@
+Name:Roadside Reaper
+ManaCost:1 R R
+Types:Creature Human Horror
+PT:3/1
+K:First Strike
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Creature.DamagedBy | TriggerZones$ Battlefield | Execute$ TrigDiscard | TriggerDescription$ Whenever a creature dealt damage by CARDNAME this turn dies, you may discard a card. If you do, put a +1/+1 counter on CARDNAME and draw a card.
+SVar:TrigDiscard:AB$ Discard | Defined$ You | NumCards$ 1 | Optional$ True | SubAbility$ DBPutCounter
+SVar:DBPutCounter:DB$ PutCounter | Defined$ Self | CounterType$ P1P1 | CounterNum$ 1 | SubAbility$ DBDraw
+SVar:DBDraw:DB$ Draw | Defined$ You | NumCards$ 1
+Oracle:First strike\nWhenever a creature dealt damage by Roadside Reaper this turn dies, you may discard a card. If you do, put a +1/+1 counter on Roadside Reaper and draw a card.

--- a/forge-gui/res/cardsfolder/VHS/shady_souvenirs.txt
+++ b/forge-gui/res/cardsfolder/VHS/shady_souvenirs.txt
@@ -1,0 +1,7 @@
+Name:Shady Souvenirs
+ManaCost:2 R
+Types:Instant
+A:SP$ Discard | Defined$ You | Mode$ Hand | SubAbility$ DBDraw | SpellDescription$ Discard your hand. Draw cards equal to the number of creatures that died this turn.
+SVar:DBDraw:DB$ Draw | Defined$ You | NumCards$ X
+SVar:X:Count$ThisTurnEntered_Graveyard_from_Battlefield_Creature
+Oracle:Discard your hand. Draw cards equal to the number of creatures that died this turn.

--- a/forge-gui/res/cardsfolder/VHS/unstoppable_slaughter.txt
+++ b/forge-gui/res/cardsfolder/VHS/unstoppable_slaughter.txt
@@ -1,0 +1,9 @@
+Name:Unstoppable Slaughter
+ManaCost:1 R R
+Types:Sorcery
+A:SP$ DamageAll | ValidCards$ Creature | ValidPlayers$ Player | NumDmg$ 1 | RememberDamaged$ True | SubAbility$ DBDelayedTrigger | SpellDescription$ CARDNAME deals 1 damage to each creature and each player. Whenever a creature dealt damage by CARDNAME this turn dies, repeat that process.
+SVar:DBDelayedTrigger:DB$ DelayedTrigger | Mode$ ChangesZone | RememberObjects$ Remembered | ValidCard$ Creature.IsTriggerRemembered | Origin$ Battlefield | Destination$ Graveyard | ThisTurn$ True | Execute$ DBRepeatDamage | SubAbility$ DBCleanup | TriggerDescription$ When a creature dealt damage this way dies this turn, repeat that process.
+SVar:DBRepeatDamage:DB$ DamageAll | ValidCards$ Creature | ValidPlayers$ Player | NumDmg$ 1 | RememberDamaged$ True | SubAbility$ DBDelayedTrigger
+T:Mode$ Phase | Phase$ End of Turn | Execute$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+Oracle:Unstoppable Slaughter deals 1 damage to each creature and each player. Whenever a creature dealt damage by Unstoppable Slaughter this turn dies this turn, repeat that process.


### PR DESCRIPTION
## Summary
- add custom VHS card scripts
- fix trigger logic for Misshapen Monstrosity and Unstoppable Slaughter
- simplify Misshapen Monstrosity trigger to track destroyed creatures only

## Testing
- `mvn -q -DskipTests install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68647a01def08320805d0f6a9912dd01