### PR TITLE
Add custom RAK cards and tokens

### DIFF
--- a/forge-gui/res/cardsfolder/RAK/level_the_landscape.txt
+++ b/forge-gui/res/cardsfolder/RAK/level_the_landscape.txt
@@ -1,0 +1,10 @@
+Name:Level the Landscape
+ManaCost:2 W
+Types:Sorcery
+A:SP$ RepeatEach | RepeatPlayers$ Player | RepeatSubAbility$ ChooseCrtr | SubAbility$ SacAllOthers | SpellDescription$ Each player chooses any number of creatures they control with total power less than or equal to the number of lands they control, then sacrifices all other creatures they control.
+SVar:ChooseCrtr:DB$ ChooseCard | Defined$ Player.IsRemembered | Choices$ Creature.RememberedPlayerCtrl | WithTotalPower$ X | Reveal$ True | RememberChosen$ True | AILogic$ NegativePowerFirst
+SVar:SacAllOthers:DB$ SacrificeAll | ValidCards$ Creature.IsNotRemembered | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:X:Count$Valid Land.RememberedPlayerCtrl
+K:TypeCycling:Plains:2
+Oracle:Each player chooses any number of creatures they control with total power less than or equal to the number of lands they control, then sacrifices all other creatures they control.\nPlainscycling {2} ({2}, Discard this card: Search your library for a Plains card, reveal it, put it into your hand, then shuffle.)

--- a/forge-gui/res/cardsfolder/RAK/new_shore_claimer.txt
+++ b/forge-gui/res/cardsfolder/RAK/new_shore_claimer.txt
@@ -1,0 +1,9 @@
+Name:New-Shore Claimer
+ManaCost:1 W
+Types:Creature Human Scout
+PT:2/2
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigSearch | CheckSVar$ Y | SVarCompare$ GTX | OptionalDecider$ You | TriggerDescription$ When CARDNAME enters the battlefield, if an opponent controls more lands than you, you may search your library for a Plains card, reveal it, put it into your hand, then shuffle.
+SVar:TrigSearch:DB$ ChangeZone | Origin$ Library | Destination$ Hand | ChangeType$ Plains | ChangeNum$ 1 | Reveal$ True | ShuffleNonMandatory$ True
+SVar:X:Count$Valid Land.YouCtrl
+SVar:Y:PlayerCountOpponents$HighestValid Land.YouCtrl
+Oracle:When New-Shore Claimer enters the battlefield, if an opponent controls more lands than you, you may search your library for a Plains card, reveal it, put it into your hand, then shuffle.

--- a/forge-gui/res/cardsfolder/RAK/omalu_guide.txt
+++ b/forge-gui/res/cardsfolder/RAK/omalu_guide.txt
@@ -1,0 +1,7 @@
+Name:Omalu Guide
+ManaCost:2 W
+Types:Creature Human Warrior
+PT:3/2
+A:AB$ Token | Cost$ W U B R G | TokenAmount$ 1 | TokenScript$ paradise | TokenOwner$ You | SpellDescription$ Voyage — Create Paradise, a legendary land token with hexproof and "{T}: Add one mana of any color."
+S:Mode$ Continuous | Affected$ Card.Self | AddPower$ 2 | AddToughness$ 2 | AddKeyword$ Vigilance | IsPresent$ Land.YouCtrl+namedParadise | PresentCompare$ GE1 | Description$ As long as you control Paradise, CARDNAME gets +2/+2 and has vigilance.
+Oracle:Voyage {W}{U}{B}{R}{G} — Create Paradise, a legendary land token with hexproof and "{T}: Add one mana of any color."\nAs long as you control Paradise, Omalu Guide gets +2/+2 and has vigilance.

--- a/forge-gui/res/cardsfolder/RAK/omalu_matron.txt
+++ b/forge-gui/res/cardsfolder/RAK/omalu_matron.txt
@@ -1,0 +1,7 @@
+Name:Omalu Matron
+ManaCost:W
+Types:Creature Human Noble
+PT:1/2
+K:Vigilance
+S:Mode$ Continuous | Affected$ Creature.namedBroken Grove Guardians+YouCtrl | AddPower$ 1 | AddToughness$ 1 | IsPresent$ Plains.YouCtrl | PresentCompare$ GE3 | Description$ Homeland — Broken Grove Guardians gets +1/+1 as long as you control three or more Plains.
+Oracle:Vigilance\nHomeland — Broken Grove Guardians gets +1/+1 as long as you control three or more Plains.

--- a/forge-gui/res/cardsfolder/RAK/omalu_prince.txt
+++ b/forge-gui/res/cardsfolder/RAK/omalu_prince.txt
@@ -1,0 +1,7 @@
+Name:Omalu Prince
+ManaCost:2 W
+Types:Creature Human Noble
+PT:3/3
+T:Mode$ Attacks | ValidCard$ Card.Self | IsPresent$ Plains.YouCtrl | PresentCompare$ GE3 | Execute$ TrigTap | TriggerDescription$ Homeland — Whenever CARDNAME attacks, if you control three or more Plains, tap target creature an opponent controls.
+SVar:TrigTap:DB$ Tap | ValidTgts$ Creature.OppCtrl | TgtPrompt$ Select target creature an opponent controls | SpellDescription$ Tap target creature an opponent controls.
+Oracle:Homeland — Whenever Omalu Prince attacks, if you control three or more Plains, tap target creature an opponent controls.

--- a/forge-gui/res/cardsfolder/RAK/oteos_homecoming.txt
+++ b/forge-gui/res/cardsfolder/RAK/oteos_homecoming.txt
@@ -1,0 +1,7 @@
+Name:Oteo's Homecoming
+ManaCost:1 W
+Types:Sorcery
+A:SP$ Effect | StaticAbilities$ STCantCast,STCantAttack | Duration$ UntilYourNextTurn | SpellDescription$ Until your next turn, players can't cast spells and creatures can't attack you or a planeswalker you control.
+SVar:STCantCast:Mode$ CantBeCast | ValidCard$ Card | Caster$ Player | Description$ Players can't cast spells.
+SVar:STCantAttack:Mode$ CantAttack | ValidCard$ Creature | Target$ You,Planeswalker.YouCtrl | Description$ Creatures can't attack you or a planeswalker you control.
+Oracle:Until your next turn, players can't cast spells and creatures can't attack you or a planeswalker you control.

--- a/forge-gui/res/cardsfolder/RAK/paradise_griffin.txt
+++ b/forge-gui/res/cardsfolder/RAK/paradise_griffin.txt
@@ -1,0 +1,9 @@
+Name:Paradise Griffin
+ManaCost:1 W
+Types:Creature Griffin
+PT:1/4
+K:Flying
+K:Vigilance
+A:AB$ Token | Cost$ W U B R G | TokenAmount$ 1 | TokenScript$ paradise | TokenOwner$ You | SpellDescription$ Voyage — Create Paradise, a legendary land token with hexproof and "{T}: Add one mana of any color."
+S:Mode$ Continuous | Affected$ Card.Self | AddPower$ 3 | IsPresent$ Land.YouCtrl+namedParadise | PresentCompare$ GE1 | Description$ As long as you control Paradise, CARDNAME gets +3/+0.
+Oracle:Flying, vigilance\nVoyage {W}{U}{B}{R}{G} — Create Paradise, a legendary land token with hexproof and "{T}: Add one mana of any color."\nAs long as you control Paradise, Paradise Griffin gets +3/+0.

--- a/forge-gui/res/cardsfolder/RAK/playful_bottlenose.txt
+++ b/forge-gui/res/cardsfolder/RAK/playful_bottlenose.txt
@@ -1,0 +1,19 @@
+Name:Playful Bottlenose
+ManaCost:W
+Types:Creature Dolphin
+PT:2/1
+A:AB$ Pump | Cost$ 0 | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | RememberTargets$ True | SubAbility$ DBFlying | SpellDescription$ Choose target creature you control. CARDNAME gains flying until end of turn if that creature has flying. The same is true for first strike, double strike, deathtouch, haste, hexproof, indestructible, lifelink, menace, reach, trample, and vigilance.
+SVar:DBFlying:DB$ Pump | Defined$ Self | KW$ Flying | Duration$ EndOfTurn | ConditionPresent$ Card.IsRemembered+withFlying | SubAbility$ DBFirstStrike
+SVar:DBFirstStrike:DB$ Pump | Defined$ Self | KW$ First Strike | Duration$ EndOfTurn | ConditionPresent$ Card.IsRemembered+withFirst Strike | SubAbility$ DBDoubleStrike
+SVar:DBDoubleStrike:DB$ Pump | Defined$ Self | KW$ Double Strike | Duration$ EndOfTurn | ConditionPresent$ Card.IsRemembered+withDouble Strike | SubAbility$ DBDeathtouch
+SVar:DBDeathtouch:DB$ Pump | Defined$ Self | KW$ Deathtouch | Duration$ EndOfTurn | ConditionPresent$ Card.IsRemembered+withDeathtouch | SubAbility$ DBHaste
+SVar:DBHaste:DB$ Pump | Defined$ Self | KW$ Haste | Duration$ EndOfTurn | ConditionPresent$ Card.IsRemembered+withHaste | SubAbility$ DBHexproof
+SVar:DBHexproof:DB$ Pump | Defined$ Self | KW$ Hexproof | Duration$ EndOfTurn | ConditionPresent$ Card.IsRemembered+withHexproof | SubAbility$ DBIndestructible
+SVar:DBIndestructible:DB$ Pump | Defined$ Self | KW$ Indestructible | Duration$ EndOfTurn | ConditionPresent$ Card.IsRemembered+withIndestructible | SubAbility$ DBLifelink
+SVar:DBLifelink:DB$ Pump | Defined$ Self | KW$ Lifelink | Duration$ EndOfTurn | ConditionPresent$ Card.IsRemembered+withLifelink | SubAbility$ DBMenace
+SVar:DBMenace:DB$ Pump | Defined$ Self | KW$ Menace | Duration$ EndOfTurn | ConditionPresent$ Card.IsRemembered+withMenace | SubAbility$ DBReach
+SVar:DBReach:DB$ Pump | Defined$ Self | KW$ Reach | Duration$ EndOfTurn | ConditionPresent$ Card.IsRemembered+withReach | SubAbility$ DBTrample
+SVar:DBTrample:DB$ Pump | Defined$ Self | KW$ Trample | Duration$ EndOfTurn | ConditionPresent$ Card.IsRemembered+withTrample | SubAbility$ DBVigilance
+SVar:DBVigilance:DB$ Pump | Defined$ Self | KW$ Vigilance | Duration$ EndOfTurn | ConditionPresent$ Card.IsRemembered+withVigilance | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+Oracle:{0}: Choose target creature you control. Playful Bottlenose gains flying until end of turn if that creature has flying. The same is true for first strike, double strike, deathtouch, haste, hexproof, indestructible, lifelink, menace, reach, trample, and vigilance.

--- a/forge-gui/res/cardsfolder/RAK/roving_home.txt
+++ b/forge-gui/res/cardsfolder/RAK/roving_home.txt
@@ -1,0 +1,9 @@
+Name:Roving Home
+ManaCost:4 W
+Types:Creature Turtle
+PT:3/5
+A:AB$ Token | Cost$ 2 U | TokenAmount$ 1 | TokenScript$ u_1_1_bird_flying | TokenOwner$ You | SpellDescription$ Create a 1/1 blue Bird creature token with flying.
+A:AB$ Token | Cost$ 2 B | TokenAmount$ 1 | TokenScript$ b_1_1_merfolk_drain | TokenOwner$ You | SpellDescription$ Create a 1/1 black Merfolk creature token with "Whenever this creature attacks, each opponent loses 1 life."
+A:AB$ Token | Cost$ 1 R | TokenAmount$ 1 | TokenScript$ r_1_1_elemental | TokenOwner$ You | SpellDescription$ Create a 1/1 red Elemental creature token.
+A:AB$ Token | Cost$ 8 G | TokenAmount$ 1 | TokenScript$ g_5_5_beast | TokenOwner$ You | SpellDescription$ Create a 5/5 green Beast creature token.
+Oracle:{2}{U}: Create a 1/1 blue Bird creature token with flying.\n{2}{B}: Create a 1/1 black Merfolk creature token with "Whenever this creature attacks, each opponent loses 1 life."\n{1}{R}: Create a 1/1 red Elemental creature token.\n{8}{G}: Create a 5/5 green Beast creature token.

--- a/forge-gui/res/cardsfolder/RAK/seasoned_crafter.txt
+++ b/forge-gui/res/cardsfolder/RAK/seasoned_crafter.txt
@@ -1,0 +1,6 @@
+Name:Seasoned Crafter
+ManaCost:1 W
+Types:Creature Elf Artificer
+PT:1/3
+A:AB$ ChangeZone | Cost$ T | Origin$ Library | Destination$ Hand | ChangeType$ Card.namedHooksword,Card.namedSturdy Canoe | ChangeNum$ 1 | Reveal$ True | Shuffle$ True | SpellDescription$ Search your library for a card named Hooksword or Sturdy Canoe, reveal it, put it into your hand, then shuffle.
+Oracle:{T}: Search your library for a card named Hooksword or Sturdy Canoe, reveal it, put it into your hand, then shuffle.

--- a/forge-gui/res/tokenscripts/b_1_1_merfolk_drain.txt
+++ b/forge-gui/res/tokenscripts/b_1_1_merfolk_drain.txt
@@ -1,0 +1,8 @@
+Name:Merfolk Token
+ManaCost:no cost
+Colors:black
+Types:Creature Merfolk
+PT:1/1
+T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigLose | TriggerDescription$ Whenever CARDNAME attacks, each opponent loses 1 life.
+SVar:TrigLose:DB$ LoseLife | Defined$ Opponent | LifeAmount$ 1 | SpellDescription$ Each opponent loses 1 life.
+Oracle:Whenever this creature attacks, each opponent loses 1 life.

--- a/forge-gui/res/tokenscripts/paradise.txt
+++ b/forge-gui/res/tokenscripts/paradise.txt
@@ -1,0 +1,6 @@
+Name:Paradise
+ManaCost:no cost
+Types:Legendary Land
+K:Hexproof
+A:AB$ Mana | Cost$ T | Produced$ Any | SpellDescription$ Add one mana of any color.
+Oracle:Hexproof\n{T}: Add one mana of any color.


### PR DESCRIPTION
## Summary
- add Level the Landscape and plainscycling support
- add New-Shore Claimer search ability
- script Omalu cards and Paradise support
- add Playful Bottlenose ability and various token producers
- include new Paradise and Merfolk Drain tokens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686f1a090d448320a6bbbcd7a2c51cfb