### PR TITLE
Add custom RAK cards

### DIFF
--- a/forge-gui/res/cardsfolder/RAK/abyssal_crevice.txt
+++ b/forge-gui/res/cardsfolder/RAK/abyssal_crevice.txt
@@ -1,0 +1,7 @@
+Name:Abyssal Crevice
+ManaCost:2 B
+Types:Enchantment
+T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigLoseLife | TriggerDescription$ At the beginning of your upkeep, you lose 2 life and create a 1/1 black Merfolk creature token with "Whenever this creature attacks, each opponent loses 1 life."
+SVar:TrigLoseLife:DB$ LoseLife | LifeAmount$ 2 | SubAbility$ DBToken
+SVar:DBToken:DB$ Token | TokenAmount$ 1 | TokenScript$ b_1_1_merfolk_drain | TokenOwner$ You
+Oracle:At the beginning of your upkeep, you lose 2 life and create a 1/1 black Merfolk creature token with "Whenever this creature attacks, each opponent loses 1 life."

--- a/forge-gui/res/cardsfolder/RAK/aswans_cunning.txt
+++ b/forge-gui/res/cardsfolder/RAK/aswans_cunning.txt
@@ -1,0 +1,5 @@
+Name:Aswan's Cunning
+ManaCost:B
+Types:Instant
+A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +2 | KW$ Indestructible | SpellDescription$ Target creature gets +2/+0 and gains indestructible until end of turn.
+Oracle:Target creature gets +2/+0 and gains indestructible until end of turn.

--- a/forge-gui/res/cardsfolder/RAK/aswans_tattoo.txt
+++ b/forge-gui/res/cardsfolder/RAK/aswans_tattoo.txt
@@ -1,0 +1,9 @@
+Name:Aswan's Tattoo
+ManaCost:1 B
+Types:Enchantment Aura Tattoo
+K:Enchant:Creature
+SVar:AttachAILogic:Pump
+T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefield | IsPresent$ Creature.EnchantedBy+Black | Execute$ TrigDraw | TriggerDescription$ When CARDNAME enters the battlefield, if enchanted creature is black, draw a card.
+SVar:TrigDraw:DB$ Draw | SpellDescription$ Draw a card.
+S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ 1 | AddToughness$ 1 | AddKeyword$ Lifelink | Description$ Enchanted creature gets +1/+1 and has lifelink.
+Oracle:When Aswan's Tattoo enters the battlefield, if enchanted creature is black, draw a card.\nEnchanted creature gets +1/+1 and has lifelink.

--- a/forge-gui/res/cardsfolder/RAK/avatar_of_the_abyss.txt
+++ b/forge-gui/res/cardsfolder/RAK/avatar_of_the_abyss.txt
@@ -1,0 +1,9 @@
+Name:Avatar of the Abyss
+ManaCost:2 B B B
+Types:Creature Avatar
+PT:5/6
+K:Flash
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self,Swamp | Execute$ TrigDamageLife | TriggerDescription$ Whenever CARDNAME or a Swamp enters the battlefield under your control, CARDNAME deals 3 damage to target player or planeswalker and you gain 3 life.
+SVar:TrigDamageLife:DB$ DealDamage | ValidTgts$ Player,Planeswalker | TgtPrompt$ Select target player or planeswalker | NumDmg$ 3 | SubAbility$ DBGainLife | SpellDescription$ CARDNAME deals 3 damage to target player or planeswalker and you gain 3 life.
+SVar:DBGainLife:DB$ GainLife | LifeAmount$ 3
+Oracle:Flash\nWhenever Avatar of the Abyss or a Swamp enters the battlefield under your control, Avatar of the Abyss deals 3 damage to target player or planeswalker and you gain 3 life.

--- a/forge-gui/res/cardsfolder/RAK/beetle_blight.txt
+++ b/forge-gui/res/cardsfolder/RAK/beetle_blight.txt
@@ -1,0 +1,6 @@
+Name:Beetle Blight
+ManaCost:3 B
+Types:Instant
+A:SP$ Destroy | ValidTgts$ Creature | TgtPrompt$ Select target creature | SubAbility$ DBLoseLife | SpellDescription$ Destroy target creature. You lose 3 life unless you control three or more Swamps.
+SVar:DBLoseLife:DB$ LoseLife | Defined$ You | LifeAmount$ 3 | ConditionPresent$ Swamp.YouCtrl | ConditionCompare$ LT3
+Oracle:Destroy target creature. Homeland — You lose 3 life unless you control three or more Swamps.

--- a/forge-gui/res/cardsfolder/RAK/blood_in_the_water.txt
+++ b/forge-gui/res/cardsfolder/RAK/blood_in_the_water.txt
@@ -1,0 +1,6 @@
+Name:Blood in the Water
+ManaCost:B
+Types:Instant
+A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ -1 | NumDef$ -1 | IsCurse$ True | SubAbility$ DBLoseLife | SpellDescription$ Target creature gets -1/-1 until end of turn. Its controller loses 1 life.
+SVar:DBLoseLife:DB$ LoseLife | Defined$ TargetedController | LifeAmount$ 1
+Oracle:Target creature gets -1/-1 until end of turn. Its controller loses 1 life.

--- a/forge-gui/res/cardsfolder/RAK/bloodstarved_aswan.txt
+++ b/forge-gui/res/cardsfolder/RAK/bloodstarved_aswan.txt
@@ -1,0 +1,8 @@
+Name:Bloodstarved Aswan
+ManaCost:4 B
+Types:Creature Vampire Shapeshifter
+PT:4/4
+T:Mode$ Attacks | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigPump | TriggerDescription$ Whenever CARDNAME attacks, you may pay {1}{B}. If you do, it gains your choice of flying or lifelink until end of turn.
+SVar:TrigPump:AB$ Pump | Cost$ 1 B | Defined$ Self | KWChoice$ Flying,Lifelink
+SVar:HasAttackEffect:TRUE
+Oracle:Whenever Bloodstarved Aswan attacks, you may pay {1}{B}. If you do, it gains your choice of flying or lifelink until end of turn.

--- a/forge-gui/res/cardsfolder/RAK/vorticers_tattoo.txt
+++ b/forge-gui/res/cardsfolder/RAK/vorticers_tattoo.txt
@@ -1,0 +1,10 @@
+Name:Vorticer's Tattoo
+ManaCost:1 U
+Types:Enchantment Aura Tattoo
+K:Enchant:Creature
+SVar:AttachAILogic:Pump
+T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefield | IsPresent$ Creature.EnchantedBy+Blue | Execute$ TrigDraw | TriggerDescription$ When CARDNAME enters the battlefield, if enchanted creature is blue, draw a card.
+SVar:TrigDraw:DB$ Draw | SpellDescription$ Draw a card.
+S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ 1 | AddToughness$ 1 | Description$ Enchanted creature gets +1/+1.
+S:Mode$ CantBlockBy | ValidAttacker$ Creature.EnchantedBy | Description$ Enchanted creature can't be blocked.
+Oracle:When Vorticer's Tattoo enters the battlefield, if enchanted creature is blue, draw a card.\nEnchanted creature gets +1/+1 and can't be blocked.

--- a/forge-gui/res/cardsfolder/RAK/voyagers_wayfinding.txt
+++ b/forge-gui/res/cardsfolder/RAK/voyagers_wayfinding.txt
@@ -1,0 +1,6 @@
+Name:Voyager's Wayfinding
+ManaCost:2 U
+Types:Instant
+A:SP$ Draw | NumCards$ X | SpellDescription$ Draw a card for each color among nonland permanents you control.
+SVar:X:Count$Valid Permanent.nonLand+YouCtrl$Colors
+Oracle:Draw a card for each color among nonland permanents you control.

--- a/forge-gui/res/cardsfolder/RAK/wavebreaker_shaman.txt
+++ b/forge-gui/res/cardsfolder/RAK/wavebreaker_shaman.txt
@@ -1,0 +1,8 @@
+Name:Wavebreaker Shaman
+ManaCost:U
+Types:Creature Merfolk Shaman
+PT:1/1
+S:Mode$ CantBlockBy | ValidAttacker$ Card.Self | Description$ CARDNAME can't be blocked.
+SVar:X:Count$Valid Island.YouCtrl
+A:AB$ PumpAll | Cost$ U Sac<1/CARDNAME> | ValidCards$ Creature.YouCtrl | KW$ Hexproof | CheckSVar$ X | SVarCompare$ GE3 | SpellDescription$ Creatures you control gain hexproof until end of turn. Activate only if you control three or more Islands.
+Oracle:CARDNAME can't be blocked.\nHomeland — {U}, Sacrifice CARDNAME: Creatures you control gain hexproof until end of turn. Activate only if you control three or more Islands.

--- a/forge-gui/res/cardsfolder/RAK/wavebreaker_shaman.txt
+++ b/forge-gui/res/cardsfolder/RAK/wavebreaker_shaman.txt
@@ -5,4 +5,4 @@ PT:1/1
 S:Mode$ CantBlockBy | ValidAttacker$ Card.Self | Description$ CARDNAME can't be blocked.
 SVar:X:Count$Valid Island.YouCtrl
 A:AB$ PumpAll | Cost$ U Sac<1/CARDNAME> | ValidCards$ Creature.YouCtrl | KW$ Hexproof | CheckSVar$ X | SVarCompare$ GE3 | SpellDescription$ Creatures you control gain hexproof until end of turn. Activate only if you control three or more Islands.
-Oracle:CARDNAME can't be blocked.\nHomeland — {U}, Sacrifice CARDNAME: Creatures you control gain hexproof until end of turn. Activate only if you control three or more Islands.
+Oracle:Wavebreaker Shaman can't be blocked.\nHomeland — {U}, Sacrifice Wavebreaker Shaman: Creatures you control gain hexproof until end of turn. Activate only if you control three or more Islands.


### PR DESCRIPTION
## Summary
- script Vorticer's Tattoo, Voyager's Wayfinding, Wavebreaker Shaman
- script Abyssal Crevice and supporting token usage
- script Aswan's Cunning and Aswan's Tattoo
- script Avatar of the Abyss
- script Beetle Blight, Blood in the Water, Bloodstarved Aswan

## Testing
- `mvn -q -DskipTests package` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687192dd7b308320991c5e3ce82a88f3