### PR TITLE
Add custom RAK cards

### DIFF
--- a/forge-gui/res/cardsfolder/RAK/burden_of_a_secret.txt
+++ b/forge-gui/res/cardsfolder/RAK/burden_of_a_secret.txt
@@ -1,0 +1,7 @@
+Name:Burden of a Secret
+ManaCost:2 B B
+Types:Sorcery
+A:SP$ ChangeZone | ValidTgts$ Player | TgtPrompt$ Select target player | Chooser$ Targeted | Origin$ Library | Destination$ Hand | ChangeType$ Card | ChangeNum$ 1 | SubAbility$ DBChoose | SpellDescription$ Target player searches their library for a card, puts it into their hand, then shuffles. Then they discard all but one card from their hand.
+SVar:DBChoose:DB$ ChooseCard | Defined$ Targeted | Mandatory$ True | TargetControls$ True | ChoiceZone$ Hand | Choices$ Card | SubAbility$ DBDiscard
+SVar:DBDiscard:DB$ Discard | Defined$ Targeted | Mode$ Defined | DefinedCards$ ValidHand Card.!ChosenCard+OwnedBy Targeted
+Oracle:Target player searches their library for a card, puts it into their hand, then shuffles. Then, they discard all but one card from their hand.

--- a/forge-gui/res/cardsfolder/RAK/consume_the_untainted.txt
+++ b/forge-gui/res/cardsfolder/RAK/consume_the_untainted.txt
@@ -1,0 +1,6 @@
+Name:Consume the Untainted
+ManaCost:2 B B
+Types:Instant
+A:SP$ Destroy | ValidTgts$ Creature,Planeswalker | TgtPrompt$ Select target creature or planeswalker | SpellDescription$ Destroy target creature or planeswalker.
+K:TypeCycling:Swamp:PayLife<2>
+Oracle:Destroy target creature or planeswalker.\nSwampcycling—Pay 2 life. (Pay 2 life, Discard this card: Search your library for a Swamp card, reveal it, put it into your hand, then shuffle.)

--- a/forge-gui/res/cardsfolder/RAK/crafty_aswan.txt
+++ b/forge-gui/res/cardsfolder/RAK/crafty_aswan.txt
@@ -2,6 +2,6 @@ Name:Crafty Aswan
 ManaCost:2 B
 Types:Creature Vampire Shapeshifter
 PT:3/3
-A:AB$ Animate | Cost$ 1 B | Defined$ Self | Power$ 5 | Toughness$ 4 | Types$ Creature,Dog | RemoveCreatureTypes$ True | Keywords$ Menace,Haste | SpellDescription$ Until end of turn, CARDNAME becomes a 5/4 Dog with menace and haste.
-A:AB$ Animate | Cost$ 1 B | Defined$ Self | Power$ 3 | Toughness$ 2 | Types$ Creature,Bat | RemoveCreatureTypes$ True | Keywords$ Flying,Lifelink | SpellDescription$ Until end of turn, CARDNAME becomes a 3/2 Bat with flying and lifelink.
+A:AB$ Animate | Cost$ 1 B | Defined$ Self | Power$ 5 | Toughness$ 4 | Types$ Creature,Dog | RemoveCreatureTypes$ True | Keywords$ Menace & Haste | SpellDescription$ Until end of turn, CARDNAME becomes a 5/4 Dog with menace and haste.
+A:AB$ Animate | Cost$ 1 B | Defined$ Self | Power$ 3 | Toughness$ 2 | Types$ Creature,Bat | RemoveCreatureTypes$ True | Keywords$ Flying & Lifelink | SpellDescription$ Until end of turn, CARDNAME becomes a 3/2 Bat with flying and lifelink.
 Oracle:{1}{B}: Until end of turn, Crafty Aswan becomes a 5/4 Dog with menace and haste.\n{1}{B}: Until end of turn, Crafty Aswan becomes a 3/2 Bat with flying and lifelink.

--- a/forge-gui/res/cardsfolder/RAK/crafty_aswan.txt
+++ b/forge-gui/res/cardsfolder/RAK/crafty_aswan.txt
@@ -1,0 +1,7 @@
+Name:Crafty Aswan
+ManaCost:2 B
+Types:Creature Vampire Shapeshifter
+PT:3/3
+A:AB$ Animate | Cost$ 1 B | Defined$ Self | Power$ 5 | Toughness$ 4 | Types$ Creature,Dog | RemoveCreatureTypes$ True | Keywords$ Menace,Haste | SpellDescription$ Until end of turn, CARDNAME becomes a 5/4 Dog with menace and haste.
+A:AB$ Animate | Cost$ 1 B | Defined$ Self | Power$ 3 | Toughness$ 2 | Types$ Creature,Bat | RemoveCreatureTypes$ True | Keywords$ Flying,Lifelink | SpellDescription$ Until end of turn, CARDNAME becomes a 3/2 Bat with flying and lifelink.
+Oracle:{1}{B}: Until end of turn, Crafty Aswan becomes a 5/4 Dog with menace and haste.\n{1}{B}: Until end of turn, Crafty Aswan becomes a 3/2 Bat with flying and lifelink.

--- a/forge-gui/res/cardsfolder/RAK/creeping_morass.txt
+++ b/forge-gui/res/cardsfolder/RAK/creeping_morass.txt
@@ -6,6 +6,6 @@ SVar:AttachAILogic:Pump
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigSearch | OptionalDecider$ You | TriggerDescription$ When CARDNAME enters the battlefield, you may search your library for a Swamp card, reveal it, put it into your hand, then shuffle.
 SVar:TrigSearch:DB$ ChangeZone | Origin$ Library | Destination$ Hand | ChangeType$ Swamp | ChangeNum$ 1 | ShuffleNonMandatory$ True
 S:Mode$ Continuous | Affected$ Land.EnchantedBy | AddAbility$ ABDrain | Description$ Enchanted land has "{B}, {T}: Target opponent loses 1 life and you gain 1 life."
-SVar:ABDrain:AB$ LoseLife | Cost$ B T | ValidTgts$ Opponent | TgtPrompt$ Select target opponent | LifeAmount$ 1 | SubAbility$ DBGain
+SVar:ABDrain:AB$ LoseLife | Cost$ B T | ValidTgts$ Opponent | TgtPrompt$ Select target opponent | LifeAmount$ 1 | SubAbility$ DBGain | SpellDescription$ Target opponent loses 1 life and you gain 1 life.
 SVar:DBGain:DB$ GainLife | Defined$ You | LifeAmount$ 1
 Oracle:Enchant land\nWhen Creeping Morass enters the battlefield, you may search your library for a Swamp card, reveal it, put it into your hand, then shuffle.\nEnchanted land has "{B}, {T}: Target opponent loses 1 life and you gain 1 life."

--- a/forge-gui/res/cardsfolder/RAK/creeping_morass.txt
+++ b/forge-gui/res/cardsfolder/RAK/creeping_morass.txt
@@ -1,0 +1,11 @@
+Name:Creeping Morass
+ManaCost:3 B
+Types:Enchantment Aura
+K:Enchant:Land
+SVar:AttachAILogic:Pump
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigSearch | OptionalDecider$ You | TriggerDescription$ When CARDNAME enters the battlefield, you may search your library for a Swamp card, reveal it, put it into your hand, then shuffle.
+SVar:TrigSearch:DB$ ChangeZone | Origin$ Library | Destination$ Hand | ChangeType$ Swamp | ChangeNum$ 1 | ShuffleNonMandatory$ True
+S:Mode$ Continuous | Affected$ Land.EnchantedBy | AddAbility$ ABDrain | Description$ Enchanted land has "{B}, {T}: Target opponent loses 1 life and you gain 1 life."
+SVar:ABDrain:AB$ LoseLife | Cost$ B T | ValidTgts$ Opponent | TgtPrompt$ Select target opponent | LifeAmount$ 1 | SubAbility$ DBGain
+SVar:DBGain:DB$ GainLife | Defined$ You | LifeAmount$ 1
+Oracle:Enchant land\nWhen Creeping Morass enters the battlefield, you may search your library for a Swamp card, reveal it, put it into your hand, then shuffle.\nEnchanted land has "{B}, {T}: Target opponent loses 1 life and you gain 1 life."

--- a/forge-gui/res/cardsfolder/RAK/deathjaw.txt
+++ b/forge-gui/res/cardsfolder/RAK/deathjaw.txt
@@ -1,0 +1,8 @@
+Name:Deathjaw
+ManaCost:4 B
+Types:Creature Lizard
+PT:3/3
+K:Flying
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | IsPresent$ Swamp.YouCtrl | PresentCompare$ GE3 | Execute$ TrigDebuff | TriggerDescription$ Homeland — When CARDNAME enters the battlefield, if you control three or more Swamps, target creature an opponent controls gets -3/-3 until end of turn.
+SVar:TrigDebuff:DB$ Pump | ValidTgts$ Creature.OppCtrl | TgtPrompt$ Select target creature an opponent controls | NumAtt$ -3 | NumDef$ -3 | SpellDescription$ Target creature an opponent controls gets -3/-3 until end of turn.
+Oracle:Flying\nHomeland — When Deathjaw enters the battlefield, if you control three or more Swamps, target creature an opponent controls gets -3/-3 until end of turn.

--- a/forge-gui/res/cardsfolder/RAK/effervescent_ada.txt
+++ b/forge-gui/res/cardsfolder/RAK/effervescent_ada.txt
@@ -1,0 +1,7 @@
+Name:Effervescent Ada
+ManaCost:1 B
+Types:Creature Shade
+PT:1/1
+A:AB$ Pump | Cost$ 2 B | NumAtt$ +2 | NumDef$ +2 | SpellDescription$ CARDNAME gets +2/+2 until end of turn.
+K:TypeCycling:Swamp:2
+Oracle:{2}{B}: Effervescent Ada gets +2/+2 until end of turn.\nSwampcycling {2} ({2}, Discard this card: Search your library for a Swamp card, reveal it, put it into your hand, then shuffle.)

--- a/forge-gui/res/cardsfolder/RAK/faithless_desecrator.txt
+++ b/forge-gui/res/cardsfolder/RAK/faithless_desecrator.txt
@@ -1,0 +1,6 @@
+Name:Faithless Desecrator
+ManaCost:1 B
+Types:Creature Human Warrior
+PT:2/2
+A:AB$ ChangeZone | Cost$ 2 B ExileFromGrave<1/CARDNAME> | ActivationZone$ Graveyard | Origin$ Graveyard | Destination$ Hand | TargetMin$ 0 | TargetMax$ 2 | ValidTgts$ Creature.YouOwn | TgtPrompt$ Select up to two target creature cards in your graveyard | IsPresent$ Swamp.YouCtrl | PresentCompare$ GE3 | SpellDescription$ Return up to two target creature cards from your graveyard to your hand. Activate this ability only if you control three or more Swamps.
+Oracle:Homeland — {2}{B}, Exile Faithless Desecrator from your graveyard: Return up to two target creature cards from your graveyard to your hand. Activate this ability only if you control three or more Swamps.

--- a/forge-gui/res/cardsfolder/RAK/grasp_of_dark_secrets.txt
+++ b/forge-gui/res/cardsfolder/RAK/grasp_of_dark_secrets.txt
@@ -1,0 +1,11 @@
+Name:Grasp of Dark Secrets
+ManaCost:2 B
+Types:Enchantment
+K:Voyage
+A:AB$ Token | Cost$ W U B R G | TokenAmount$ 1 | TokenScript$ paradise | TokenOwner$ You | SpellDescription$ Voyage — Create Paradise, a legendary land token with hexproof and "{T}: Add one mana of any color."
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | TargetMin$ 0 | TargetMax$ 1 | Execute$ TrigDebuff | TriggerDescription$ When CARDNAME enters the battlefield, up to one target creature gets -3/-3 until end of turn.
+SVar:TrigDebuff:DB$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ -3 | NumDef$ -3 | SpellDescription$ Target creature gets -3/-3 until end of turn.
+SVar:X:Count$Valid Land.YouCtrl+namedParadise
+T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | CheckSVar$ X | SVarCompare$ GE1 | TriggerZones$ Battlefield | Execute$ TrigDrain | TriggerDescription$ At the beginning of your end step, if you control Paradise, target opponent loses 3 life.
+SVar:TrigDrain:DB$ LoseLife | ValidTgts$ Opponent | LifeAmount$ 3
+Oracle:Voyage ({W}{U}{B}{R}{G}: Create Paradise, a legendary land token with hexproof and "{T}: Add one mana of any color.")\nWhen Grasp of Dark Secrets enters the battlefield, up to one target creature gets -3/-3 until end of turn.\nAt the beginning of your end step, if you control Paradise, target opponent loses 3 life.

--- a/forge-gui/res/cardsfolder/RAK/grasp_the_currents.txt
+++ b/forge-gui/res/cardsfolder/RAK/grasp_the_currents.txt
@@ -1,0 +1,5 @@
+Name:Grasp the Currents
+ManaCost:1 B
+Types:Sorcery
+A:SP$ ChangeZoneAll | ChangeType$ Card.YouOwn+withTypeCycling | Origin$ Graveyard | Destination$ Hand | SpellDescription$ Return all cards with landcycling abilities from your graveyard to your hand.
+Oracle:Return all cards with landcycling abilities from your graveyard to your hand.

--- a/forge-gui/res/cardsfolder/RAK/grim_tikbalang.txt
+++ b/forge-gui/res/cardsfolder/RAK/grim_tikbalang.txt
@@ -1,0 +1,7 @@
+Name:Grim Tikbalang
+ManaCost:1 B
+Types:Creature Nightmare Horse
+PT:*/*
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of Swamps you control.
+SVar:X:Count$Valid Swamp.YouCtrl
+Oracle:Grim Tikbalang's power and toughness are each equal to the number of Swamps you control.


### PR DESCRIPTION
## Summary
- script custom cards for the RAK set
- add Burden of a Secret, Consume the Untainted, Crafty Aswan
- add Creeping Morass, Deathjaw, Effervescent Ada, Faithless Desecrator
- add Grasp of Dark Secrets, Grasp the Currents, Grim Tikbalang

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871941cf1c0832097ce96ebee3525ac