### PR TITLE
Fix Pelagic Peddler AI logic

### DIFF
--- a/forge-gui/res/cardsfolder/RAK/haku_haku_dredgers.txt
+++ b/forge-gui/res/cardsfolder/RAK/haku_haku_dredgers.txt
@@ -1,0 +1,7 @@
+Name:Haku Haku Dredgers
+ManaCost:2 B
+Types:Creature Human Peasant
+PT:2/3
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDraw | TriggerDescription$ When CARDNAME enters the battlefield, you may pay 3 life. If you do, draw a card.
+SVar:TrigDraw:DB$ Draw | Defined$ You | NumCards$ 1 | UnlessCost$ PayLife<3> | UnlessPayer$ You | UnlessSwitched$ True
+Oracle:When Haku Haku Dredgers enters the battlefield, you may pay 3 life. If you do, draw a card.

--- a/forge-gui/res/cardsfolder/RAK/haku_haku_thug.txt
+++ b/forge-gui/res/cardsfolder/RAK/haku_haku_thug.txt
@@ -1,0 +1,7 @@
+Name:Haku Haku Thug
+ManaCost:1 B
+Types:Creature Merfolk Rogue
+PT:2/1
+A:AB$ LoseLife | Cost$ T | ValidTgts$ Opponent | TgtPrompt$ Select target opponent | LifeAmount$ 1 | IsPresent$ Swamp.YouCtrl | PresentCompare$ GE3 | SubAbility$ DBGain | SpellDescription$ Target opponent loses 1 life and you gain 1 life. Activate this ability only if you control three or more Swamps.
+SVar:DBGain:DB$ GainLife | Defined$ You | LifeAmount$ 1
+Oracle:Homeland — {T}: Target opponent loses 1 life and you gain 1 life. Activate this ability only if you control three or more Swamps.

--- a/forge-gui/res/cardsfolder/RAK/haku_haku_tyrant.txt
+++ b/forge-gui/res/cardsfolder/RAK/haku_haku_tyrant.txt
@@ -1,0 +1,8 @@
+Name:Haku Haku Tyrant
+ManaCost:3 B
+Types:Creature Human Noble
+PT:3/4
+K:Voyage
+A:AB$ Token | Cost$ W U B R G | TokenAmount$ 1 | TokenScript$ paradise | TokenOwner$ You | SpellDescription$ Voyage — Create Paradise, a legendary land token with hexproof and "{T}: Add one mana of any color."
+S:Mode$ Continuous | Affected$ Card.Self | AddPower$ 2 | AddKeyword$ Menace | IsPresent$ Land.YouCtrl+namedParadise | PresentCompare$ GE1 | Description$ As long as you control Paradise, CARDNAME gets +2/+0 and has menace.
+Oracle:Voyage ({W}{U}{B}{R}{G}: Create Paradise, a legendary land token with hexproof and "{T}: Add one mana of any color.")\nAs long as you control Paradise, Haku Haku Tyrant gets +2/+0 and has menace.

--- a/forge-gui/res/cardsfolder/RAK/kanokai_the_deep_blood.txt
+++ b/forge-gui/res/cardsfolder/RAK/kanokai_the_deep_blood.txt
@@ -1,0 +1,9 @@
+Name:Kanokai, the Deep Blood
+ManaCost:1 B
+Types:Legendary Creature Merfolk Warrior
+PT:2/2
+K:Flash
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigGrant | TriggerDescription$ When CARDNAME enters the battlefield, Merfolk cards in your graveyard gain flash and you may cast them this turn.
+SVar:TrigGrant:DB$ Effect | StaticAbilities$ GrantFlash | Duration$ EndOfTurn
+SVar:GrantFlash:Mode$ Continuous | Affected$ Merfolk.YouOwn | AffectedZone$ Graveyard | AddKeyword$ Flash | MayPlay$ True | Description$ Merfolk cards in your graveyard gain flash and you may cast them.
+Oracle:Flash\nWhen Kanokai, the Deep Blood enters the battlefield, Merfolk cards in your graveyard gain flash and "You may cast this card from your graveyard" until end of turn.

--- a/forge-gui/res/cardsfolder/RAK/kanokais_orders.txt
+++ b/forge-gui/res/cardsfolder/RAK/kanokais_orders.txt
@@ -1,0 +1,7 @@
+Name:Kanokai's Orders
+ManaCost:1 B
+Types:Sorcery
+A:SP$ Draw | NumCards$ 2 | SubAbility$ DBLoseLife | SpellDescription$ You draw two cards. You lose 4 life unless an opponent lost life this turn.
+SVar:DBLoseLife:DB$ LoseLife | Defined$ You | LifeAmount$ 4 | ConditionCheckSVar$ X | ConditionSVarCompare$ EQ0
+SVar:X:Count$LifeOppsLostThisTurn
+Oracle:You draw two cards. You lose 4 life unless an opponent lost life this turn.

--- a/forge-gui/res/cardsfolder/RAK/make_prey.txt
+++ b/forge-gui/res/cardsfolder/RAK/make_prey.txt
@@ -1,0 +1,6 @@
+Name:Make Prey
+ManaCost:1 B B
+Types:Instant
+A:SP$ ChangeZone | Origin$ Battlefield | Destination$ Exile | ValidTgts$ Creature.cmcLE3,Enchantment.cmcLE3 | TgtPrompt$ Select target creature or enchantment with mana value 3 or less | SubAbility$ DBGain | SpellDescription$ Exile target creature or enchantment with mana value 3 or less. You gain 3 life.
+SVar:DBGain:DB$ GainLife | Defined$ You | LifeAmount$ 3
+Oracle:Exile target creature or enchantment if it has mana value 3 or less. You gain 3 life.

--- a/forge-gui/res/cardsfolder/RAK/murk_feeder.txt
+++ b/forge-gui/res/cardsfolder/RAK/murk_feeder.txt
@@ -1,0 +1,7 @@
+Name:Murk Feeder
+ManaCost:1 B
+Types:Creature Fish
+PT:2/1
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigSearch | TriggerDescription$ When CARDNAME dies, search your library for a Swamp card, reveal it, put it into your hand, then shuffle.
+SVar:TrigSearch:DB$ ChangeZone | Origin$ Library | Destination$ Hand | ChangeType$ Swamp | ChangeNum$ 1 | Reveal$ True | ShuffleNonMandatory$ True
+Oracle:When Murk Feeder dies, search your library for a Swamp card, reveal it, put it into your hand, then shuffle.

--- a/forge-gui/res/cardsfolder/RAK/muronos_demands.txt
+++ b/forge-gui/res/cardsfolder/RAK/muronos_demands.txt
@@ -1,0 +1,7 @@
+Name:Murono's Demands
+ManaCost:1 B
+Types:Sorcery
+A:SP$ LoseLife | ValidTgts$ Opponent | TgtPrompt$ Select target opponent | LifeAmount$ 3 | SubAbility$ DBGain | SpellDescription$ Target opponent loses 3 life and you gain 3 life.
+SVar:DBGain:DB$ GainLife | Defined$ You | LifeAmount$ 3
+K:Awaken:3:5 B
+Oracle:Target opponent loses 3 life and you gain 3 life.\nAwaken 3—{5}{B} (If you cast this spell for {5}{B}, also put three +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)

--- a/forge-gui/res/cardsfolder/RAK/muronos_malediction.txt
+++ b/forge-gui/res/cardsfolder/RAK/muronos_malediction.txt
@@ -1,0 +1,6 @@
+Name:Murono's Malediction
+ManaCost:1 B
+Types:Sorcery
+A:SP$ Sacrifice | Defined$ Player.Opponent | SacValid$ Creature | SpellDescription$ Each opponent sacrifices a creature.
+K:Awaken:3:4 B
+Oracle:Each opponent sacrifices a creature.\nAwaken 3—{4}{B} (If you cast this spell for {4}{B}, also put three +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)

--- a/forge-gui/res/cardsfolder/RAK/pelagic_peddler.txt
+++ b/forge-gui/res/cardsfolder/RAK/pelagic_peddler.txt
@@ -1,0 +1,14 @@
+Name:Pelagic Peddler
+ManaCost:1 B
+Types:Creature Merfolk Rogue
+PT:2/2
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigReveal | TriggerDescription$ When CARDNAME enters the battlefield, reveal the top card of your library. Any opponent may pay 2 life. If a player does, exile it. Otherwise, put it into your hand.
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigReveal | TriggerDescription$ When CARDNAME dies, reveal the top card of your library. Any opponent may pay 2 life. If a player does, exile it. Otherwise, put it into your hand.
+SVar:TrigReveal:DB$ PeekAndReveal | PeekAmount$ 1 | RevealValid$ Card | ImprintRevealed$ True | SubAbility$ DBChoice
+SVar:DBChoice:DB$ GenericChoice | Defined$ Opponent | TempRemember$ Chooser | Choices$ DBPay,DoNothing | ChoicePrompt$ Pay 2 life to exile it? | ConditionDefined$ Imprinted | ConditionPresent$ Card | ConditionCompare$ EQ1 | SubAbility$ DBToHand
+SVar:DoNothing:DB$ Cleanup | SpellDescription$ No
+SVar:DBPay:DB$ LoseLife | Defined$ Remembered | LifeAmount$ 2 | SubAbility$ DBExile | SpellDescription$ Yes
+SVar:DBExile:DB$ ChangeZone | Origin$ Library | Destination$ Exile | Defined$ Imprinted | Unimprint$ True | SubAbility$ DBCleanup
+SVar:DBToHand:DB$ ChangeZone | Origin$ Library | Destination$ Hand | Defined$ Imprinted | Unimprint$ True | ConditionDefined$ Imprinted | ConditionPresent$ Card | ConditionCompare$ GE1 | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True | ClearImprinted$ True
+Oracle:When Pelagic Peddler enters the battlefield or dies, reveal the top card of your library. Any opponent may pay 2 life. If any player does, exile it. Otherwise, put it into your hand.


### PR DESCRIPTION
## Summary
- correct GenericChoice logic in Pelagic Peddler to prevent cost parsing crash
- retain previous custom RAK cards

## Testing
- `mvn -q -DskipTests package` *(fails: Unresolveable build extension)*

------
https://chatgpt.com/codex/tasks/task_e_68881f94285483208aa900cab7a938c7