### PR TITLE
Add custom RAK cards

### DIFF
--- a/forge-gui/res/cardsfolder/RAK/avatar_of_the_volcano.txt
+++ b/forge-gui/res/cardsfolder/RAK/avatar_of_the_volcano.txt
@@ -1,0 +1,8 @@
+Name:Avatar of the Volcano
+ManaCost:2 R R R
+Types:Creature Avatar
+PT:6/5
+K:Menace
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self,Mountain.YouCtrl | Execute$ TrigToken | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME or a Mountain enters the battlefield under your control, create two 1/1 red Elemental creature tokens. They gain haste until end of turn.
+SVar:TrigToken:DB$ Token | TokenAmount$ 2 | TokenScript$ r_1_1_elemental | TokenOwner$ You | PumpKeywords$ Haste | PumpDuration$ EOT
+Oracle:Menace\nWhenever Avatar of the Volcano or a Mountain enters the battlefield under your control, create two 1/1 red Elemental creature tokens. They gain haste until end of turn.

--- a/forge-gui/res/cardsfolder/RAK/rahokes_pact.txt
+++ b/forge-gui/res/cardsfolder/RAK/rahokes_pact.txt
@@ -1,0 +1,11 @@
+Name:Rahoke's Pact
+ManaCost:3 B
+Types:Enchantment
+K:Awaken:4:6 B
+T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigSac | TriggerDescription$ At the beginning of your upkeep, sacrifice a creature. If you do, you draw two cards. Otherwise, you lose the game.
+SVar:TrigSac:DB$ Sacrifice | Defined$ You | SacValid$ Creature | RememberSacrificed$ True | SubAbility$ DBDraw | SpellDescription$ Sacrifice a creature. If you do, you draw two cards. Otherwise, you lose the game.
+SVar:DBDraw:DB$ Draw | Defined$ You | NumCards$ 2 | ConditionCheckSVar$ X | ConditionSVarCompare$ GE1 | SubAbility$ DBLose
+SVar:DBLose:DB$ LosesGame | Defined$ You | ConditionCheckSVar$ X | ConditionSVarCompare$ EQ0 | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:X:Remembered$Amount
+Oracle:At the beginning of your upkeep, sacrifice a creature. If you do, you draw two cards. Otherwise, you lose the game.\nAwaken 4—{6}{B} (When you cast this spell for {6}{B}, put four +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)

--- a/forge-gui/res/cardsfolder/RAK/reemergence.txt
+++ b/forge-gui/res/cardsfolder/RAK/reemergence.txt
@@ -1,0 +1,7 @@
+Name:Reemergence
+ManaCost:1 B B
+Types:Sorcery
+A:SP$ ChangeZone | Origin$ Graveyard | Destination$ Battlefield | ValidTgts$ Creature.YouOwn | TgtPrompt$ Choose target creature card in your graveyard | RememberChanged$ True | SubAbility$ DBAnimate | SpellDescription$ Return target creature card from your graveyard to the battlefield. It gains haste until end of turn. Return it to your hand at the beginning of the next end step.
+SVar:DBAnimate:DB$ Animate | Keywords$ Haste | Defined$ Remembered | Duration$ Permanent | AtEOT$ Hand | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+Oracle:Return target creature card from your graveyard to the battlefield. It gains haste until end of turn. Return it to your hand at the beginning of the next end step.

--- a/forge-gui/res/cardsfolder/RAK/riptide_ambusher.txt
+++ b/forge-gui/res/cardsfolder/RAK/riptide_ambusher.txt
@@ -1,0 +1,8 @@
+Name:Riptide Ambusher
+ManaCost:4 B
+Types:Creature Merfolk Warrior
+PT:3/3
+K:Flash
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigToken | TriggerZones$ Battlefield | TriggerDescription$ When CARDNAME dies, create two 1/1 black Merfolk creature token with "Whenever this creature attacks, each opponent loses 1 life."
+SVar:TrigToken:DB$ Token | TokenAmount$ 2 | TokenScript$ b_1_1_merfolk_drain
+Oracle:Flash\nWhen Riptide Ambusher dies, create two 1/1 black Merfolk creature token with "Whenever this creature attacks, each opponent loses 1 life."

--- a/forge-gui/res/cardsfolder/RAK/sharkling_attack.txt
+++ b/forge-gui/res/cardsfolder/RAK/sharkling_attack.txt
@@ -1,0 +1,5 @@
+Name:Sharkling Attack
+ManaCost:2 B
+Types:Sorcery
+A:SP$ Token | TokenAmount$ 2 | TokenScript$ b_1_1_merfolk_drain | TokenOwner$ You | SpellDescription$ Create two 1/1 black Merfolk creature tokens with "Whenever this creature attacks, each opponent loses 1 life."
+Oracle:Create two 1/1 black Merfolk creature tokens with "Whenever this creature attacks, each opponent loses 1 life."

--- a/forge-gui/res/cardsfolder/RAK/shoal_swallower.txt
+++ b/forge-gui/res/cardsfolder/RAK/shoal_swallower.txt
@@ -1,0 +1,11 @@
+Name:Shoal Swallower
+ManaCost:4 B B
+Types:Creature Leviathan
+PT:5/5
+K:Flying
+T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Opponent | CombatDamage$ True | Execute$ TrigExile | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME deals combat damage to an opponent, that player reveals the top five cards of their library. Exile each nonland card revealed this way, and that player mills the rest. For as long as those cards remain exiled, you may cast them, and you may spend mana as though it was mana of any color to cast them.
+SVar:TrigExile:DB$ Dig | DigNum$ 5 | Defined$ TriggeredTarget | Reveal$ True | ChangeNum$ All | ChangeValid$ Card.nonLand | DestinationZone$ Exile | DestinationZone2$ Graveyard | RememberChanged$ True | SubAbility$ DBEffect
+SVar:DBEffect:DB$ Effect | RememberObjects$ Remembered | StaticAbilities$ STPlay | Duration$ Permanent | ForgetOnMoved$ Exile | SubAbility$ DBCleanup
+SVar:STPlay:Mode$ Continuous | MayPlay$ True | MayPlayIgnoreColor$ True | Affected$ Card.IsRemembered+nonLand | AffectedZone$ Exile | Description$ For as long as those cards remain exiled, you may cast them, and you may spend mana as though it was mana of any color to cast them.
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+Oracle:Flying\nWhenever Shoal Swallower deals combat damage to an opponent, that player reveals the top five cards of their library. Exile each nonland card revealed this way, and that player mills the rest. For as long as those cards remain exiled, you may cast them, and you may spend mana as though it was mana of any color to cast them.

--- a/forge-gui/res/cardsfolder/RAK/third_tooth_brute.txt
+++ b/forge-gui/res/cardsfolder/RAK/third_tooth_brute.txt
@@ -1,0 +1,9 @@
+Name:Third-Tooth Brute
+ManaCost:2 B
+Types:Creature Merfolk Warrior
+PT:2/4
+T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigLife | TriggerDescription$ At the beginning of your end step, each opponent that lost life this turn loses 1 life. You gain life equal to the life lost this way.
+SVar:TrigLife:DB$ LoseLife | Defined$ Opponent.LostLifeThisTurn | LifeAmount$ 1 | SubAbility$ DBGain
+SVar:DBGain:DB$ GainLife | Defined$ You | LifeAmount$ X
+SVar:X:PlayerCountRegisteredOpponents$HasPropertyLostLifeThisTurn
+Oracle:At the beginning of your end step, each opponent that lost life this turn loses 1 life. You gain life equal to the life lost this way.

--- a/forge-gui/res/cardsfolder/RAK/third_tooth_ravager.txt
+++ b/forge-gui/res/cardsfolder/RAK/third_tooth_ravager.txt
@@ -4,4 +4,4 @@ Types:Creature Merfolk Warrior
 PT:3/3
 K:etbCounter:P1P1:2:CheckSVar$ X:CARDNAME enters the battlefield with two +1/+1 counters on it if an opponent lost life this turn.
 SVar:X:Count$LifeOppsLostThisTurn
-Oracle:CARDNAME enters the battlefield with two +1/+1 counters on it if an opponent lost life this turn.
+Oracle:Third-Tooth Ravager enters the battlefield with two +1/+1 counters on it if an opponent lost life this turn.

--- a/forge-gui/res/cardsfolder/RAK/third_tooth_ravager.txt
+++ b/forge-gui/res/cardsfolder/RAK/third_tooth_ravager.txt
@@ -1,0 +1,7 @@
+Name:Third-Tooth Ravager
+ManaCost:2 B B
+Types:Creature Merfolk Warrior
+PT:3/3
+K:etbCounter:P1P1:2:CheckSVar$ X:CARDNAME enters the battlefield with two +1/+1 counters on it if an opponent lost life this turn.
+SVar:X:Count$LifeOppsLostThisTurn
+Oracle:CARDNAME enters the battlefield with two +1/+1 counters on it if an opponent lost life this turn.

--- a/forge-gui/res/cardsfolder/RAK/toll_of_the_death_gods.txt
+++ b/forge-gui/res/cardsfolder/RAK/toll_of_the_death_gods.txt
@@ -1,0 +1,8 @@
+Name:Toll of the Death Gods
+ManaCost:2 B
+Types:Enchantment Aura
+K:Enchant:Creature
+K:Awaken:2:4 B
+SVar:AttachAILogic:Curse
+S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ -2 | AddToughness$ -2 | Description$ Enchanted creature gets -2/-2.
+Oracle:Enchant creature\nEnchanted creature gets -2/-2.\nAwaken 2—{4}{B} (When you cast this spell for {4}{B}, put two +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)

--- a/forge-gui/res/cardsfolder/RAK/tua_rahi_spotwing.txt
+++ b/forge-gui/res/cardsfolder/RAK/tua_rahi_spotwing.txt
@@ -1,0 +1,9 @@
+Name:Tua Rahi Spotwing
+ManaCost:1 B
+Types:Creature Bat
+PT:1/3
+K:Flying
+K:Voyage
+A:AB$ Token | Cost$ W U B R G | TokenAmount$ 1 | TokenScript$ paradise | TokenOwner$ You | SpellDescription$ Voyage — Create Paradise, a legendary land token with hexproof and "{T}: Add one mana of any color."
+S:Mode$ Continuous | Affected$ Card.Self | AddPower$ 1 | AddToughness$ 1 | AddKeyword$ Lifelink | IsPresent$ Land.YouCtrl+namedParadise | PresentCompare$ GE1 | Description$ As long as you control Paradise, CARDNAME gets +1/+1 and has lifelink.
+Oracle:Flying\nVoyage ({W}{U}{B}{R}{G}: Create Paradise, a legendary land token with hexproof and "{T}: Add one mana of any color.")\nAs long as you control Paradise, Tua Rahi Spotwing gets +1/+1 and has lifelink.


### PR DESCRIPTION
## Summary
- add Rahoke's Pact with upkeep sacrifice trigger and Awaken
- add Reemergence reanimation sorcery
- add Riptide Ambusher, Sharkling Attack, and Shoal Swallower
- add Third-Tooth Brute, Third-Tooth Ravager, and Tua Rahi Spotwing
- add Toll of the Death Gods aura and Avatar of the Volcano

## Testing
- `mvn -q -pl forge-gui-desktop -am test` *(fails: Unresolveable build extension)*

------
https://chatgpt.com/codex/tasks/task_e_68884e73f618832098310f7510229006