### PR TITLE
Add custom RAK card scripts

### DIFF
--- a/forge-gui/res/cardsfolder/RAK/bombardment_zone.txt
+++ b/forge-gui/res/cardsfolder/RAK/bombardment_zone.txt
@@ -1,0 +1,6 @@
+Name:Bombardment Zone
+ManaCost:3 R R
+Types:Enchantment
+A:AB$ DealDamage | Cost$ Discard<1/Land> | ValidTgts$ Any | NumDmg$ 3 | SpellDescription$ CARDNAME deals 3 damage to any target.
+K:TypeCycling:Mountain:2
+Oracle:Discard a land card: Bombardment Zone deals 3 damage to any target.\nMountaincycling {2} ({2}, Discard this card: Search your library for a Mountain card, reveal it, put it into your hand, then shuffle.)

--- a/forge-gui/res/cardsfolder/RAK/brewing_storm.txt
+++ b/forge-gui/res/cardsfolder/RAK/brewing_storm.txt
@@ -1,0 +1,7 @@
+Name:Brewing Storm
+ManaCost:1 R
+Types:Enchantment
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigScry | TriggerDescription$ When CARDNAME enters the battlefield, scry 2.
+SVar:TrigScry:DB$ Scry | ScryNum$ 2
+A:AB$ CopySpellAbility | Cost$ R Sac<1/CARDNAME> | TgtPrompt$ Select target instant or sorcery spell you control | ValidTgts$ Instant.YouCtrl,Sorcery.YouCtrl | TargetType$ Spell | MayChooseTarget$ True | SpellDescription$ Copy target instant or sorcery spell you control. You may choose new targets for the copy.
+Oracle:When Brewing Storm enters the battlefield, scry 2.\n{R}, Sacrifice Brewing Storm: Copy target instant or sorcery spell you control. You may choose new targets for the copy.

--- a/forge-gui/res/cardsfolder/RAK/caldera_tyrant.txt
+++ b/forge-gui/res/cardsfolder/RAK/caldera_tyrant.txt
@@ -7,7 +7,7 @@ T:Mode$ Attacks | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ Tr
 SVar:TrigExile:DB$ Dig | Defined$ You | DigNum$ 5 | ChangeNum$ All | DestinationZone$ Exile | RememberChanged$ True | SubAbility$ DBEffect
 SVar:DBEffect:DB$ Effect | RememberObjects$ RememberedCard | StaticAbilities$ STPlay | SubAbility$ DBPump | ForgetOnMoved$ Exile | Duration$ EndOfTurn
 SVar:STPlay:Mode$ Continuous | MayPlay$ True | Affected$ Card.IsRemembered | AffectedZone$ Exile | Description$ You may play those cards this turn.
-SVar:X:Count$Valid Card.IsRemembered+Land
+SVar:X:Count$ValidExile Card.IsRemembered+Land
 SVar:DBPump:DB$ Pump | Defined$ Self | NumAtt$ +X | SubAbility$ DBCleanup | SpellDescription$ CARDNAME gets +X/+0 until end of turn.
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 Oracle:Flying\nWhenever Caldera Tyrant attacks, exile the top five cards of your library. Until end of turn, you may play cards exiled this way. Caldera Tyrant gets +1/+0 until end of turn for each land card exiled this way.

--- a/forge-gui/res/cardsfolder/RAK/caldera_tyrant.txt
+++ b/forge-gui/res/cardsfolder/RAK/caldera_tyrant.txt
@@ -1,0 +1,13 @@
+Name:Caldera Tyrant
+ManaCost:5 R R
+Types:Creature Dragon
+PT:6/6
+K:Flying
+T:Mode$ Attacks | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigExile | TriggerDescription$ Whenever CARDNAME attacks, exile the top five cards of your library. Until end of turn, you may play cards exiled this way. CARDNAME gets +1/+0 until end of turn for each land card exiled this way.
+SVar:TrigExile:DB$ Dig | Defined$ You | DigNum$ 5 | ChangeNum$ All | DestinationZone$ Exile | RememberChanged$ True | SubAbility$ DBEffect
+SVar:DBEffect:DB$ Effect | RememberObjects$ RememberedCard | StaticAbilities$ STPlay | SubAbility$ DBPump | ForgetOnMoved$ Exile | Duration$ EndOfTurn
+SVar:STPlay:Mode$ Continuous | MayPlay$ True | Affected$ Card.IsRemembered | AffectedZone$ Exile | Description$ You may play those cards this turn.
+SVar:X:Count$Valid Card.IsRemembered+Land
+SVar:DBPump:DB$ Pump | Defined$ Self | NumAtt$ +X | SubAbility$ DBCleanup | SpellDescription$ CARDNAME gets +X/+0 until end of turn.
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+Oracle:Flying\nWhenever Caldera Tyrant attacks, exile the top five cards of your library. Until end of turn, you may play cards exiled this way. Caldera Tyrant gets +1/+0 until end of turn for each land card exiled this way.

--- a/forge-gui/res/cardsfolder/RAK/call_of_the_fire_gods.txt
+++ b/forge-gui/res/cardsfolder/RAK/call_of_the_fire_gods.txt
@@ -1,0 +1,6 @@
+Name:Call of the Fire Gods
+ManaCost:2 R
+Types:Sorcery
+A:SP$ Token | TokenAmount$ 2 | TokenScript$ r_1_1_elemental | TokenOwner$ You | SpellDescription$ Create two 1/1 red Elemental creature tokens.
+K:Awaken:3:5 R
+Oracle:Create two 1/1 red Elemental creature tokens.\nAwaken 3—{5}{R} (If you cast this spell for {5}{R}, also put three +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)

--- a/forge-gui/res/cardsfolder/RAK/champions_tattoo.txt
+++ b/forge-gui/res/cardsfolder/RAK/champions_tattoo.txt
@@ -1,0 +1,9 @@
+Name:Champion's Tattoo
+ManaCost:2 R
+Types:Enchantment Aura Tattoo
+K:Enchant:Creature
+SVar:AttachAILogic:Pump
+T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefield | IsPresent$ Creature.EnchantedBy+Red | Execute$ TrigDraw | TriggerDescription$ When CARDNAME enters the battlefield, if enchanted creature is red, draw a card.
+SVar:TrigDraw:DB$ Draw | SpellDescription$ Draw a card.
+S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ 3 | AddKeyword$ Menace | Description$ Enchanted creature gets +3/+0 and has menace.
+Oracle:When Champion's Tattoo enters the battlefield, if enchanted creature is red, draw a card.\nEnchanted creature gets +3/+0 and has menace.

--- a/forge-gui/res/cardsfolder/RAK/crater_walker.txt
+++ b/forge-gui/res/cardsfolder/RAK/crater_walker.txt
@@ -4,5 +4,5 @@ Types:Creature Elemental Giant
 PT:5/5
 K:Haste
 T:Mode$ Attacks | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigDestroy | TriggerDescription$ Whenever CARDNAME attacks, choose a non-red, non-Mountain permanent at random. Destroy that permanent.
-SVar:TrigDestroy:DB$ Destroy | ValidTgts$ Permanent.nonRed,!Mountain | TargetsAtRandom$ True
+SVar:TrigDestroy:DB$ Destroy | ValidTgts$ Permanent.nonRed+nonMountain | TargetsAtRandom$ True
 Oracle:Haste\nWhenever Crater Walker attacks, choose a non-red, non-Mountain permanent at random. Destroy that permanent.

--- a/forge-gui/res/cardsfolder/RAK/crater_walker.txt
+++ b/forge-gui/res/cardsfolder/RAK/crater_walker.txt
@@ -1,0 +1,8 @@
+Name:Crater Walker
+ManaCost:4 R R
+Types:Creature Elemental Giant
+PT:5/5
+K:Haste
+T:Mode$ Attacks | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigDestroy | TriggerDescription$ Whenever CARDNAME attacks, choose a non-red, non-Mountain permanent at random. Destroy that permanent.
+SVar:TrigDestroy:DB$ Destroy | ValidTgts$ Permanent.nonRed,!Mountain | TargetsAtRandom$ True
+Oracle:Haste\nWhenever Crater Walker attacks, choose a non-red, non-Mountain permanent at random. Destroy that permanent.

--- a/forge-gui/res/cardsfolder/RAK/crest_the_waters.txt
+++ b/forge-gui/res/cardsfolder/RAK/crest_the_waters.txt
@@ -1,0 +1,10 @@
+Name:Crest the Waters
+ManaCost:2 R
+Types:Enchantment
+K:Voyage
+A:AB$ Token | Cost$ W U B R G | TokenAmount$ 1 | TokenScript$ paradise | TokenOwner$ You | SpellDescription$ Voyage — Create Paradise, a legendary land token with hexproof and "{T}: Add one mana of any color."
+S:Mode$ Continuous | Affected$ Creature.YouCtrl | AddKeyword$ Haste | Description$ Creatures you control have haste.
+SVar:X:Count$Valid Land.YouCtrl+namedParadise
+T:Mode$ Phase | Phase$ BeginCombat | ValidPlayer$ You | CheckSVar$ X | SVarCompare$ GE1 | TriggerZones$ Battlefield | Execute$ TrigPut | TriggerDescription$ At the beginning of combat on your turn, if you control Paradise, you may put a creature card from your hand onto the battlefield.
+SVar:TrigPut:DB$ ChangeZone | Origin$ Hand | Destination$ Battlefield | ChangeType$ Creature | ChangeNum$ 1 | Optional$ True
+Oracle:Voyage ({W}{U}{B}{R}{G}: Create Paradise, a legendary land token with hexproof and "{T}: Add one mana of any color.")\nCreatures you control have haste.\nAt the beginning of combat on your turn, if you control Paradise, you may put a creature card from your hand onto the battlefield.

--- a/forge-gui/res/cardsfolder/RAK/dazzling_sarimanok.txt
+++ b/forge-gui/res/cardsfolder/RAK/dazzling_sarimanok.txt
@@ -1,0 +1,6 @@
+Name:Dazzling Sarimanok
+ManaCost:1 R
+Types:Creature Bird
+PT:1/3
+A:AB$ Mana | Cost$ 1 T Sac<1/CARDNAME> | Produced$ Combo Any | Amount$ 2 | SpellDescription$ Add two mana in any combination of colors.
+Oracle:{1}, {T}, Sacrifice Dazzling Sarimanok: Add two mana in any combination of colors.

--- a/forge-gui/res/cardsfolder/RAK/devotee_of_kalanua.txt
+++ b/forge-gui/res/cardsfolder/RAK/devotee_of_kalanua.txt
@@ -2,9 +2,9 @@ Name:Devotee of Kalanua
 ManaCost:1 R
 Types:Creature Elemental Bard
 PT:2/2
-T:Mode$ SpellCast | ValidSA$ Instant,Sorcery | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | CheckSVar$ Y | SVarCompare$ GE5 | Execute$ TrigCounter | TriggerDescription$ Whenever you cast an instant or sorcery spell, if you spent 5 or more mana to cast that spell, put a +1/+1 counter on CARDNAME.
+T:Mode$ SpellCast | ValidCard$ Instant,Sorcery | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigBranch | TriggerDescription$ Whenever you cast an instant or sorcery spell, CARDNAME gets +1/+1 until end of turn. If you spent 5 or more mana to cast that spell, put a +1/+1 counter on CARDNAME instead.
+SVar:TrigBranch:DB$ Branch | BranchConditionSVar$ Y | BranchConditionSVarCompare$ GE5 | TrueSubAbility$ TrigCounter | FalseSubAbility$ TrigPump
 SVar:TrigCounter:DB$ PutCounter | Defined$ Self | CounterType$ P1P1 | CounterNum$ 1
-T:Mode$ SpellCast | ValidSA$ Instant,Sorcery | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | CheckSVar$ Y | SVarCompare$ LT5 | Execute$ TrigPump | TriggerDescription$ Whenever you cast an instant or sorcery spell, CARDNAME gets +1/+1 until end of turn.
 SVar:TrigPump:DB$ Pump | Defined$ Self | NumAtt$ +1 | NumDef$ +1
 SVar:Y:TriggeredCard$CastTotalManaSpent
 Oracle:Whenever you cast an instant or sorcery spell, Devotee of Kalanua gets +1/+1 until end of turn. If you spent 5 or more mana to cast that spell, put a +1/+1 counter on Devotee of Kalanua instead.

--- a/forge-gui/res/cardsfolder/RAK/devotee_of_kalanua.txt
+++ b/forge-gui/res/cardsfolder/RAK/devotee_of_kalanua.txt
@@ -1,0 +1,10 @@
+Name:Devotee of Kalanua
+ManaCost:1 R
+Types:Creature Elemental Bard
+PT:2/2
+T:Mode$ SpellCast | ValidSA$ Instant,Sorcery | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | CheckSVar$ Y | SVarCompare$ GE5 | Execute$ TrigCounter | TriggerDescription$ Whenever you cast an instant or sorcery spell, if you spent 5 or more mana to cast that spell, put a +1/+1 counter on CARDNAME.
+SVar:TrigCounter:DB$ PutCounter | Defined$ Self | CounterType$ P1P1 | CounterNum$ 1
+T:Mode$ SpellCast | ValidSA$ Instant,Sorcery | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | CheckSVar$ Y | SVarCompare$ LT5 | Execute$ TrigPump | TriggerDescription$ Whenever you cast an instant or sorcery spell, CARDNAME gets +1/+1 until end of turn.
+SVar:TrigPump:DB$ Pump | Defined$ Self | NumAtt$ +1 | NumDef$ +1
+SVar:Y:TriggeredCard$CastTotalManaSpent
+Oracle:Whenever you cast an instant or sorcery spell, Devotee of Kalanua gets +1/+1 until end of turn. If you spent 5 or more mana to cast that spell, put a +1/+1 counter on Devotee of Kalanua instead.

--- a/forge-gui/res/cardsfolder/RAK/draconic_vigor.txt
+++ b/forge-gui/res/cardsfolder/RAK/draconic_vigor.txt
@@ -1,0 +1,10 @@
+Name:Draconic Vigor
+ManaCost:2 R
+Types:Sorcery
+A:SP$ Dig | Defined$ You | DigNum$ 3 | ChangeNum$ All | DestinationZone$ Exile | RememberChanged$ True | SubAbility$ DBEffect | SpellDescription$ Exile the top three cards of your library. Until end of turn, you may play cards exiled this way. CARDNAME deals 1 damage to each opponent for each land card exiled this way.
+SVar:DBEffect:DB$ Effect | RememberObjects$ RememberedCard | StaticAbilities$ STPlay | SubAbility$ DBDamage | ForgetOnMoved$ Exile | Duration$ EndOfTurn
+SVar:STPlay:Mode$ Continuous | MayPlay$ True | Affected$ Card.IsRemembered | AffectedZone$ Exile | Description$ You may play those cards this turn.
+SVar:X:Count$Valid Card.IsRemembered+Land
+SVar:DBDamage:DB$ DamageAll | Defined$ Opponent | NumDmg$ X | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+Oracle:Exile the top three cards of your library. Until end of turn, you may play cards exiled this way. Draconic Vigor deals 1 damage to each opponent for each land card exiled this way.

--- a/forge-gui/res/cardsfolder/RAK/draconic_vigor.txt
+++ b/forge-gui/res/cardsfolder/RAK/draconic_vigor.txt
@@ -4,7 +4,7 @@ Types:Sorcery
 A:SP$ Dig | Defined$ You | DigNum$ 3 | ChangeNum$ All | DestinationZone$ Exile | RememberChanged$ True | SubAbility$ DBEffect | SpellDescription$ Exile the top three cards of your library. Until end of turn, you may play cards exiled this way. CARDNAME deals 1 damage to each opponent for each land card exiled this way.
 SVar:DBEffect:DB$ Effect | RememberObjects$ RememberedCard | StaticAbilities$ STPlay | SubAbility$ DBDamage | ForgetOnMoved$ Exile | Duration$ EndOfTurn
 SVar:STPlay:Mode$ Continuous | MayPlay$ True | Affected$ Card.IsRemembered | AffectedZone$ Exile | Description$ You may play those cards this turn.
-SVar:X:Count$Valid Card.IsRemembered+Land
-SVar:DBDamage:DB$ DamageAll | Defined$ Opponent | NumDmg$ X | SubAbility$ DBCleanup
+SVar:X:Count$ValidExile Card.IsRemembered+Land
+SVar:DBDamage:DB$ DamageAll | ValidPlayers$ Player.Opponent | NumDmg$ X | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 Oracle:Exile the top three cards of your library. Until end of turn, you may play cards exiled this way. Draconic Vigor deals 1 damage to each opponent for each land card exiled this way.


### PR DESCRIPTION
## Summary
- add Bombardment Zone, Brewing Storm, Caldera Tyrant, Call of the Fire Gods
- add Champion’s Tattoo, Crater Walker, Crest the Waters
- add Dazzling Sarimanok, Devotee of Kalanua, Draconic Vigor

## Testing
- `mvn -DskipTests=false test` *(fails: Unresolveable build extension org.apache.maven.wagon:wagon-ftp:3.5.3)*

------
https://chatgpt.com/codex/tasks/task_e_6888f4f8f084832095a4063ee82ad401