### PR TITLE
Add RAK custom card scripts

### DIFF
--- a/forge-gui/res/cardsfolder/RAK/dual_destruction.txt
+++ b/forge-gui/res/cardsfolder/RAK/dual_destruction.txt
@@ -1,0 +1,5 @@
+Name:Dual Destruction
+ManaCost:4 R
+Types:Instant
+A:SP$ DealDamage | ValidTgts$ Creature,Planeswalker | TargetMin$ 0 | TargetMax$ 2 | TgtPrompt$ Select target creature and/or planeswalkers | NumDmg$ 3 | SpellDescription$ CARDNAME deals 3 damage to each of up to two target creatures and/or planeswalkers.
+Oracle:Dual Destruction deals 3 damage to each of up to two target creatures and/or planeswalkers.

--- a/forge-gui/res/cardsfolder/RAK/harness_the_eruption.txt
+++ b/forge-gui/res/cardsfolder/RAK/harness_the_eruption.txt
@@ -1,0 +1,10 @@
+Name:Harness the Eruption
+ManaCost:3 R R
+Types:Sorcery
+A:SP$ Dig | Defined$ You | DigNum$ 4 | ChangeNum$ All | DestinationZone$ Exile | RememberChanged$ True | SubAbility$ DBEffect | SpellDescription$ Exile the top four cards of your library. Until end of turn, you may play cards exiled this way. Add {R}{R}{R} for each land card exiled this way. Until end of turn, you don't lose this mana as steps and phases end.
+SVar:DBEffect:DB$ Effect | RememberObjects$ RememberedCard | StaticAbilities$ STPlay | SubAbility$ DBMana | ForgetOnMoved$ Exile | Duration$ EndOfTurn
+SVar:STPlay:Mode$ Continuous | MayPlay$ True | Affected$ Card.IsRemembered | AffectedZone$ Exile | Description$ You may play those cards this turn.
+SVar:X:Count$ValidExile Card.IsRemembered+Land/Times.3
+SVar:DBMana:DB$ Mana | Produced$ R | Amount$ X | PersistentMana$ True | SubAbility$ DBCleanup | SpellDescription$ Add {R}{R}{R} for each land card exiled this way. Until end of turn, you don't lose this mana as steps and phases end.
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+Oracle:Exile the top four cards of your library. Until end of turn, you may play cards exiled this way. Add {R}{R}{R} for each land card exiled this way. Until end of turn, you don't lose this mana as steps and phases end.

--- a/forge-gui/res/cardsfolder/RAK/heartfire_dance.txt
+++ b/forge-gui/res/cardsfolder/RAK/heartfire_dance.txt
@@ -1,0 +1,5 @@
+Name:Heartfire Dance
+ManaCost:2 R
+Types:Instant
+A:SP$ PumpAll | ValidCards$ Creature.YouCtrl | NumAtt$ +2 | SpellDescription$ Creatures you control get +2/+0 until end of turn.
+Oracle:Creatures you control get +2/+0 until end of turn.

--- a/forge-gui/res/cardsfolder/RAK/hupiris_rebirth.txt
+++ b/forge-gui/res/cardsfolder/RAK/hupiris_rebirth.txt
@@ -1,0 +1,7 @@
+Name:Hupiri's Rebirth
+ManaCost:1 R
+Types:Sorcery
+A:SP$ Discard | Mode$ TgtChoose | NumCards$ 1 | SubAbility$ DBDraw | SpellDescription$ Discard a card, then draw two cards.
+SVar:DBDraw:DB$ Draw | NumCards$ 2
+K:Awaken:3:3 R
+Oracle:Discard a card, then draw two cards.\nAwaken 3—{3}{R} (If you cast this spell for {3}{R}, also put three +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)

--- a/forge-gui/res/cardsfolder/RAK/kalanuas_wrath.txt
+++ b/forge-gui/res/cardsfolder/RAK/kalanuas_wrath.txt
@@ -1,0 +1,6 @@
+Name:Kalanua's Wrath
+ManaCost:3 R R
+Types:Sorcery
+A:SP$ DamageAll | NumDmg$ 5 | ValidCards$ Creature.nonLand,Planeswalker | ValidDescription$ each nonland creature and each planeswalker. | SpellDescription$ CARDNAME deals 5 damage to each nonland creature and each planeswalker.
+K:Awaken:5:5 R R R
+Oracle:Kalanua's Wrath deals 5 damage to each nonland creature and each planeswalker.\nAwaken 5—{5}{R}{R}{R} (If you cast this spell for {5}{R}{R}{R}, also put five +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)

--- a/forge-gui/res/cardsfolder/RAK/lava_blast.txt
+++ b/forge-gui/res/cardsfolder/RAK/lava_blast.txt
@@ -1,0 +1,6 @@
+Name:Lava Blast
+ManaCost:6 R
+Types:Sorcery
+A:SP$ DealDamage | ValidTgts$ Any | NumDmg$ 7 | SpellDescription$ CARDNAME deals 7 damage to any target.
+K:TypeCycling:Mountain:2
+Oracle:Lava Blast deals 7 damage to any target.\nMountaincycling {2} ({2}, Discard this card: Search your library for a Mountain card, reveal it, put it into your hand, then shuffle.)

--- a/forge-gui/res/cardsfolder/RAK/lava_tubes_quarry.txt
+++ b/forge-gui/res/cardsfolder/RAK/lava_tubes_quarry.txt
@@ -1,0 +1,7 @@
+Name:Lava Tubes Quarry
+ManaCost:1 R
+Types:Creature Elemental Boar
+PT:2/2
+K:Haste
+A:AB$ Token | Cost$ 1 R ExileFromGrave<1/CARDNAME> | ActivationZone$ Graveyard | TokenAmount$ 2 | TokenScript$ r_1_1_elemental | TokenOwner$ You | SorcerySpeed$ True | IsPresent$ Mountain.YouCtrl | PresentCompare$ GE3 | SpellDescription$ Create two 1/1 red Elemental creature tokens. Activate only as a sorcery and only if you control three or more Mountains.
+Oracle:Haste\nHomeland — {1}{R}, Exile Lava Tubes Quarry from your graveyard: Create two 1/1 red Elemental creature tokens. Activate only as a sorcery and only if you control three or more Mountains.

--- a/forge-gui/res/cardsfolder/RAK/lavaflow_fields.txt
+++ b/forge-gui/res/cardsfolder/RAK/lavaflow_fields.txt
@@ -1,0 +1,10 @@
+Name:Lavaflow Fields
+ManaCost:2 R
+Types:Enchantment Aura
+K:Enchant:Land
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | OptionalDecider$ You | Execute$ TrigSearch | TriggerDescription$ When CARDNAME enters the battlefield, you may search your library for a Mountain card, reveal it, put it into your hand, then shuffle.
+SVar:TrigSearch:DB$ ChangeZone | Origin$ Library | Destination$ Hand | ChangeType$ Mountain | ChangeNum$ 1 | ShuffleNonMandatory$ True
+S:Mode$ Continuous | Affected$ Land.EnchantedBy | AddAbility$ Ping | Description$ Enchanted land has "{R}, {T}: This land deals 1 damage to any target."
+SVar:Ping:AB$ DealDamage | Cost$ R T | ValidTgts$ Any | NumDmg$ 1 | SpellDescription$ This land deals 1 damage to any target.
+SVar:NonStackingAttachEffect:True
+Oracle:Enchant land\nWhen Lavaflow Fields enters the battlefield, you may search your library for a Mountain card, reveal it, put it into your hand, then shuffle.\nEnchanted land has "{R}, {T}: This land deals 1 damage to any target."

--- a/forge-gui/res/cardsfolder/RAK/leviathan_beam.txt
+++ b/forge-gui/res/cardsfolder/RAK/leviathan_beam.txt
@@ -1,0 +1,7 @@
+Name:Leviathan Beam
+ManaCost:2 R R
+Types:Sorcery
+T:Mode$ SpellCast | ValidCard$ Card.Self | ValidActivatingPlayer$ You | IsPresent$ Creature.powerGE5+YouCtrl | Execute$ TrigCopy | TriggerDescription$ When you cast this spell, if you control a creature with power 5 or greater, copy this spell. You may choose new targets for the copy.
+SVar:TrigCopy:DB$ CopySpellAbility | Defined$ TriggeredSpellAbility | MayChooseTarget$ True
+A:SP$ DealDamage | ValidTgts$ Creature,Planeswalker | TgtPrompt$ Select target creature or planeswalker | NumDmg$ 5 | SpellDescription$ CARDNAME deals 5 damage to target creature or planeswalker.
+Oracle:When you cast this spell, if you control a creature with power 5 or greater, copy this spell. You may choose new targets for the copy.\nLeviathan Beam deals 5 damage to target creature or planeswalker.

--- a/forge-gui/res/cardsfolder/RAK/loyalist_champion.txt
+++ b/forge-gui/res/cardsfolder/RAK/loyalist_champion.txt
@@ -1,0 +1,10 @@
+Name:Loyalist Champion
+ManaCost:1 R R
+Types:Creature Human Warrior
+PT:3/3
+K:First Strike
+T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigRetake | TriggerDescription$ At the beginning of your end step, each player gains control of all permanents they own.
+SVar:TrigRetake:DB$ GainControlVariant | AllValid$ Permanent | ChangeController$ CardOwner
+T:Mode$ SpellCast | ValidCard$ Card | ValidActivatingPlayer$ Player | TargetsValid$ Permanent.!ControlledBy TriggeredActivator | TriggerZones$ Battlefield | Execute$ TrigDamage | TriggerDescription$ Whenever a player casts a spell that targets a permanent they don't control, CARDNAME deals 3 damage to that player.
+SVar:TrigDamage:DB$ DealDamage | Defined$ TriggeredActivator | NumDmg$ 3
+Oracle:First strike\nAt the beginning of your end step, each player gains control of all permanents they own.\nWhenever a player casts a spell that targets a permanent they don't control, Loyalist Champion deals 3 damage to that player.


### PR DESCRIPTION
## Summary
- add Dual Destruction and other red cards for RAK set
- include Awaken spells, aura, token-making creature, and others

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68893950876c832089b0cc44c248354d