### PR TITLE
Add custom RAK red cards

### DIFF
--- a/forge-gui/res/cardsfolder/RAK/loyalty_shift.txt
+++ b/forge-gui/res/cardsfolder/RAK/loyalty_shift.txt
@@ -1,0 +1,7 @@
+Name:Loyalty Shift
+ManaCost:2 R
+Types:Sorcery
+K:Awaken:2:4 R
+A:SP$ GainControl | ValidTgts$ Creature | TgtPrompt$ Select target creature | LoseControl$ EOT | Untap$ True | AddKWs$ Haste | SpellDescription$ Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn.
+SVar:PlayMain1:OPPONENTCREATURES
+Oracle:Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn.\nAwaken 2—{4}{R} (If you cast this spell for {4}{R}, also put two +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)

--- a/forge-gui/res/cardsfolder/RAK/magma_maul.txt
+++ b/forge-gui/res/cardsfolder/RAK/magma_maul.txt
@@ -1,0 +1,6 @@
+Name:Magma Maul
+ManaCost:2 R
+Types:Sorcery
+A:SP$ DealDamage | ValidTgts$ Creature,Planeswalker | TgtPrompt$ Select target creature or planeswalker | NumDmg$ 3 | SubAbility$ DBDamageCtrl | SpellDescription$ Magma Maul deals 3 damage to target creature or planeswalker. If you control three or more Mountains, Magma Maul deals 3 damage to that permanent's controller.
+SVar:DBDamageCtrl:DB$ DealDamage | Defined$ TargetedController | NumDmg$ 3 | ConditionPresent$ Mountain.YouCtrl | ConditionCompare$ GE3 | SpellDescription$ If you control three or more Mountains, CARDNAME deals 3 damage to that permanent's controller.
+Oracle:Homeland — Magma Maul deals 3 damage to target creature or planeswalker. If you control three or more Mountains, Magma Maul deals 3 damage to that permanent's controller.

--- a/forge-gui/res/cardsfolder/RAK/maw_of_rahoke.txt
+++ b/forge-gui/res/cardsfolder/RAK/maw_of_rahoke.txt
@@ -1,0 +1,7 @@
+Name:Maw of Rahoke
+ManaCost:X R
+Types:Sorcery
+K:Awaken:X:X R R R
+A:SP$ DealDamage | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ X | References$ X | SpellDescription$ CARDNAME deals X damage to target creature.
+SVar:X:Count$xPaid
+Oracle:Maw of Rahoke deals X damage to target creature.\nAwaken X—{X}{R}{R}{R} (If you cast this spell for {X}{R}{R}{R}, also put X +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)

--- a/forge-gui/res/cardsfolder/RAK/meke_champion.txt
+++ b/forge-gui/res/cardsfolder/RAK/meke_champion.txt
@@ -1,0 +1,8 @@
+Name:Meke Champion
+ManaCost:2 R
+Types:Creature Human Warrior
+PT:2/3
+K:Voyage
+A:AB$ Token | Cost$ W U B R G | TokenAmount$ 1 | TokenScript$ paradise | TokenOwner$ You | SpellDescription$ Voyage — Create Paradise, a legendary land token with hexproof and "{T}: Add one mana of any color."
+S:Mode$ Continuous | Affected$ Card.Self | AddKeyword$ Double Strike | IsPresent$ Land.YouCtrl+namedParadise | PresentCompare$ GE1 | Description$ Meke Champion has double strike as long as you control Paradise.
+Oracle:Voyage ({W}{U}{B}{R}{G}: Create Paradise, a legendary land token with hexproof and "{T}: Add one mana of any color.")\nMeke Champion has double strike as long as you control Paradise.

--- a/forge-gui/res/cardsfolder/RAK/meke_lavarunner.txt
+++ b/forge-gui/res/cardsfolder/RAK/meke_lavarunner.txt
@@ -1,0 +1,6 @@
+Name:Meke Lavarunner
+ManaCost:3 R
+Types:Creature Human Warrior
+PT:4/3
+S:Mode$ Continuous | Affected$ Card.Self | AddKeyword$ Haste | IsPresent$ Mountain.YouCtrl | PresentCompare$ GE3 | Description$ Homeland — CARDNAME has haste as long as you control three or more Mountains.
+Oracle:Homeland — Meke Lavarunner has haste as long as you control three or more Mountains.

--- a/forge-gui/res/cardsfolder/RAK/pantheon_celebrant.txt
+++ b/forge-gui/res/cardsfolder/RAK/pantheon_celebrant.txt
@@ -1,0 +1,6 @@
+Name:Pantheon Celebrant
+ManaCost:2 R
+Types:Creature Human Shaman
+PT:2/3
+S:Mode$ ReduceCost | ValidCard$ Card | ValidSA$ Awaken | Type$ Spell | Activator$ You | Amount$ 2 | Description$ Spells you cast for their awaken costs cost {2} less to cast.
+Oracle:Spells you cast for their awaken costs cost {2} less to cast.

--- a/forge-gui/res/cardsfolder/RAK/rupture_field.txt
+++ b/forge-gui/res/cardsfolder/RAK/rupture_field.txt
@@ -1,0 +1,5 @@
+Name:Rupture Field
+ManaCost:1 R
+Types:Enchantment
+A:AB$ DealDamage | Cost$ 1 R Sac<1/Creature> | ValidTgts$ Any | TgtPrompt$ Select any target | NumDmg$ 2 | SpellDescription$ CARDNAME deals 2 damage to any target.
+Oracle:{1}{R}, Sacrifice a creature: Rupture Field deals 2 damage to any target.

--- a/forge-gui/res/cardsfolder/RAK/sunset_horizon.txt
+++ b/forge-gui/res/cardsfolder/RAK/sunset_horizon.txt
@@ -1,0 +1,9 @@
+Name:Sunset Horizon
+ManaCost:2 R
+Types:Enchantment Aura
+K:Enchant:Land
+SVar:AttachAILogic:Pump
+S:Mode$ Continuous | Affected$ Land.AttachedBy | AddAbility$ DBLoot | Description$ Enchanted land has "{T}, Discard a card: Draw a card."
+SVar:DBLoot:AB$ Draw | Cost$ T Discard<1/Card> | NumCards$ 1 | SpellDescription$ Draw a card.
+SVar:NonStackingAttachEffect:True
+Oracle:Enchant land\nEnchanted land has "{T}, Discard a card: Draw a card."

--- a/forge-gui/res/cardsfolder/RAK/tua_rahi_sentry.txt
+++ b/forge-gui/res/cardsfolder/RAK/tua_rahi_sentry.txt
@@ -1,0 +1,11 @@
+Name:Tua Rahi Sentry
+ManaCost:2 R
+Types:Creature Elemental
+PT:3/2
+K:Reach
+K:Voyage
+A:AB$ Token | Cost$ W U B R G | TokenAmount$ 1 | TokenScript$ paradise | TokenOwner$ You | SpellDescription$ Voyage — Create Paradise, a legendary land token with hexproof and "{T}: Add one mana of any color."
+SVar:X:Count$Valid Land.YouCtrl+namedParadise
+T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | CheckSVar$ X | SVarCompare$ GE1 | TriggerZones$ Battlefield | Execute$ TrigDamage | TriggerDescription$ At the beginning of your upkeep, if you control Paradise, CARDNAME deals 2 damage to each opponent.
+SVar:TrigDamage:DB$ DamageAll | ValidPlayers$ Player.Opponent | NumDmg$ 2
+Oracle:Reach\nVoyage ({W}{U}{B}{R}{G}: Create Paradise, a legendary land token with hexproof and "{T}: Add one mana of any color.")\nAt the beginning of your upkeep, if you control Paradise, Tua Rahi Sentry deals 2 damage to each opponent.

--- a/forge-gui/res/cardsfolder/RAK/utaman_avenger.txt
+++ b/forge-gui/res/cardsfolder/RAK/utaman_avenger.txt
@@ -1,0 +1,9 @@
+Name:Utaman Avenger
+ManaCost:2 R
+Types:Creature Elemental Warrior
+PT:2/2
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters the battlefield, create a 1/1 red Elemental creature token.
+SVar:TrigToken:DB$ Token | TokenAmount$ 1 | TokenScript$ r_1_1_elemental | TokenOwner$ You
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self,Elemental.Other+YouCtrl | TriggerZones$ Battlefield | Execute$ TrigDamage | TriggerDescription$ Whenever an Elemental you control dies, CARDNAME deals 1 damage to any target.
+SVar:TrigDamage:DB$ DealDamage | ValidTgts$ Any | NumDmg$ 1
+Oracle:When Utaman Avenger enters the battlefield, create a 1/1 red Elemental creature token.\nWhenever an Elemental you control dies, Utaman Avenger deals 1 damage to any target.


### PR DESCRIPTION
## Summary
- script Loyalty Shift with awaken control effect
- add several red Homeland and Voyage creatures
- implement support enchantments and burn spells for RAK set

## Testing
- `mvn -q -pl forge-gui -am test` *(fails: Unresolveable build extension: Plugin org.apache.maven.wagon:wagon-ftp:3.5.3)*

------
https://chatgpt.com/codex/tasks/task_e_688aca4a15f08320bd8f16b5ee69ecbc