### PR TITLE
Add RAK custom card scripts and tokens

### DIFF
--- a/forge-gui/res/cardsfolder/RAK/avatar_of_the_jungle.txt
+++ b/forge-gui/res/cardsfolder/RAK/avatar_of_the_jungle.txt
@@ -1,0 +1,10 @@
+Name:Avatar of the Jungle
+ManaCost:2 G G G
+Types:Creature Avatar
+PT:5/6
+K:Reach
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self,Forest.YouCtrl | TriggerZones$ Battlefield | Execute$ TrigAnimate | TriggerDescription$ Whenever CARDNAME or a Forest enters the battlefield under your control, put three +1/+1 counters on up to one target noncreature land you control. Untap it. It becomes a 0/0 Elemental creature with haste that's still a land.
+SVar:TrigAnimate:DB$ PutCounter | CounterType$ P1P1 | CounterNum$ 3 | ValidTgts$ Land.nonCreature+YouCtrl | TargetMin$ 0 | TargetMax$ 1 | TgtPrompt$ Select up to one target noncreature land you control | SubAbility$ DBUntap
+SVar:DBUntap:DB$ Untap | Defined$ Targeted | SubAbility$ DBAnimate
+SVar:DBAnimate:DB$ Animate | Defined$ Targeted | Power$ 0 | Toughness$ 0 | Types$ Creature,Elemental | Keywords$ Haste | Duration$ Permanent
+Oracle:Reach\nWhenever Avatar of the Jungle or a Forest enters the battlefield under your control, put three +1/+1 counters on up to one target noncreature land you control. Untap it. It becomes a 0/0 Elemental creature with haste that's still a land.

--- a/forge-gui/res/cardsfolder/RAK/barkskin_pummeler.txt
+++ b/forge-gui/res/cardsfolder/RAK/barkskin_pummeler.txt
@@ -1,0 +1,8 @@
+Name:Barkskin Pummeler
+ManaCost:4 G
+Types:Creature Dryad
+PT:4/4
+S:Mode$ Continuous | CharacteristicDefining$ True | Affected$ Card.Self | AddKeyword$ Flash | IsPresent$ Forest.YouCtrl | PresentCompare$ GE3 | Description$ Homeland — This spell has flash as long as you control three or more Forests.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigPump | TriggerDescription$ When CARDNAME enters the battlefield, target creature gets +3/+3 until end of turn.
+SVar:TrigPump:DB$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +3 | NumDef$ +3 | SpellDescription$ Target creature gets +3/+3 until end of turn.
+Oracle:Homeland — This spell has flash as long as you control three or more Forests.\nWhen Barkskin Pummeler enters the battlefield, target creature gets +3/+3 until end of turn.

--- a/forge-gui/res/cardsfolder/RAK/beastmasters_tattoo.txt
+++ b/forge-gui/res/cardsfolder/RAK/beastmasters_tattoo.txt
@@ -1,0 +1,9 @@
+Name:Beastmaster's Tattoo
+ManaCost:3 G
+Types:Enchantment Aura Tattoo
+K:Enchant:Creature
+SVar:AttachAILogic:Pump
+T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefield | IsPresent$ Creature.EnchantedBy+Green | Execute$ TrigDraw | TriggerDescription$ When CARDNAME enters the battlefield, if enchanted creature is green, draw a card.
+SVar:TrigDraw:DB$ Draw | SpellDescription$ Draw a card.
+S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ 2 | AddToughness$ 2 | AddKeyword$ Trample | Description$ Enchanted creature gets +2/+2 and has trample.
+Oracle:When Beastmaster's Tattoo enters the battlefield, if enchanted creature is green, draw a card.\nEnchanted creature gets +2/+2 and has trample.

--- a/forge-gui/res/cardsfolder/RAK/caretaker_of_paradise.txt
+++ b/forge-gui/res/cardsfolder/RAK/caretaker_of_paradise.txt
@@ -1,0 +1,6 @@
+Name:Caretaker of Paradise
+ManaCost:G
+Types:Creature Human Spellshaper
+PT:0/1
+A:AB$ Token | Cost$ G T Discard<1/Card> | TokenAmount$ 1 | TokenScript$ birds_of_paradise | TokenOwner$ You | SpellDescription$ {G}, {T}, Discard a card: Create a 0/1 green Bird creature token named Birds of Paradise with flying and "{T}: Add one mana of any color."
+Oracle:{G}, {T}, Discard a card: Create a 0/1 green Bird creature token named Birds of Paradise. It has flying and "{T}: Add one mana of any color."

--- a/forge-gui/res/cardsfolder/RAK/crowd_of_kakamora.txt
+++ b/forge-gui/res/cardsfolder/RAK/crowd_of_kakamora.txt
@@ -1,0 +1,11 @@
+Name:Crowd of Kakamora
+ManaCost:X G G
+Types:Creature Ouphe
+PT:0/0
+K:Trample
+K:Vigilance
+K:etbCounter:P1P1:Z:no Condition:CARDNAME enters the battlefield with twice X +1/+1 counters on it.
+SVar:X:Count$xPaid
+SVar:Z:SVar$X/Twice
+K:TypeCycling:Forest:2
+Oracle:Trample, vigilance\nCrowd of Kakamora enters the battlefield with twice X +1/+1 counters on it.\nForestcycling {2} ({2}, Discard this card: Search your library for a Forest card, reveal it, put it into your hand, then shuffle.)

--- a/forge-gui/res/cardsfolder/RAK/haven_of_the_earth_gods.txt
+++ b/forge-gui/res/cardsfolder/RAK/haven_of_the_earth_gods.txt
@@ -1,0 +1,9 @@
+Name:Haven of the Earth Gods
+ManaCost:2 G
+Types:Enchantment Aura
+K:Enchant:Land
+SVar:AttachAILogic:Pump
+T:Mode$ TapsForMana | ValidCard$ Card.AttachedBy | TriggerZones$ Battlefield | Execute$ TrigMana | Static$ True | TriggerDescription$ Whenever enchanted land is tapped for mana, add an additional one mana of any color.
+SVar:TrigMana:DB$ Mana | Produced$ Any | Defined$ TriggeredCardController
+K:Awaken:4:5 G
+Oracle:Enchant land\nWhenever enchanted land is tapped for mana, add an additional one mana of any color.\nAwaken 4—{5}{G} (When you cast this spell for {5}{G}, put four +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)

--- a/forge-gui/res/cardsfolder/RAK/heart_of_the_gods.txt
+++ b/forge-gui/res/cardsfolder/RAK/heart_of_the_gods.txt
@@ -1,0 +1,10 @@
+Name:Heart of the Gods
+ManaCost:5 G
+Types:Creature Elemental
+PT:8/8
+K:Voyage
+A:AB$ Token | Cost$ W U B R G | TokenAmount$ 1 | TokenScript$ paradise | TokenOwner$ You | SpellDescription$ Voyage — Create Paradise, a legendary land token with hexproof and "{T}: Add one mana of any color."
+SVar:X:Count$Valid Land.YouCtrl+namedParadise
+S:Mode$ Continuous | Affected$ Card.Self | AddKeyword$ Vigilance & Reach & Trample & Hexproof & Haste | CheckSVar$ X | SVarCompare$ GE1 | Description$ As long as you control Paradise, CARDNAME has vigilance, reach, trample, hexproof, and haste.
+DeckHas:Ability$Token
+Oracle:Voyage ({W}{U}{B}{R}{G}: Create Paradise, a legendary land token with hexproof and "{T}: Add one mana of any color.")\nAs long as you control Paradise, Heart of the Gods has vigilance, reach, trample, hexproof, and haste.

--- a/forge-gui/res/cardsfolder/RAK/utaman_bruiser.txt
+++ b/forge-gui/res/cardsfolder/RAK/utaman_bruiser.txt
@@ -1,0 +1,7 @@
+Name:Utaman Bruiser
+ManaCost:R
+Types:Creature Elemental Warrior
+PT:1/1
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME dies, create a 1/1 red Elemental creature token.
+SVar:TrigToken:DB$ Token | TokenAmount$ 1 | TokenScript$ r_1_1_elemental | TokenOwner$ You | SpellDescription$ Create a 1/1 red Elemental creature token.
+Oracle:When Utaman Bruiser dies, create a 1/1 red Elemental creature token.

--- a/forge-gui/res/cardsfolder/RAK/utaman_challenger.txt
+++ b/forge-gui/res/cardsfolder/RAK/utaman_challenger.txt
@@ -1,0 +1,6 @@
+Name:Utaman Challenger
+ManaCost:2 R
+Types:Creature Elemental Bard Warrior
+PT:3/2
+S:Mode$ Continuous | Affected$ Creature.Other+YouCtrl | AddPower$ 1 | IsPresent$ Mountain.YouCtrl | PresentCompare$ GE3 | Description$ Homeland — Other creatures you control get +1/+0 as long as you control three or more Mountains.
+Oracle:Homeland — Other creatures you control get +1/+0 as long as you control three or more Mountains.

--- a/forge-gui/res/cardsfolder/RAK/utaman_daring.txt
+++ b/forge-gui/res/cardsfolder/RAK/utaman_daring.txt
@@ -1,0 +1,5 @@
+Name:Utaman Daring
+ManaCost:1 R
+Types:Instant
+A:SP$ DealDamage | Cost$ 1 R Sac<1/Creature> | ValidTgts$ Any | NumDmg$ 4 | SpellDescription$ As an additional cost to cast this spell, sacrifice a creature. CARDNAME deals 4 damage to any target.
+Oracle:As an additional cost to cast this spell, sacrifice a creature.\nUtaman Daring deals 4 damage to any target.

--- a/forge-gui/res/tokenscripts/RAK/birds_of_paradise.txt
+++ b/forge-gui/res/tokenscripts/RAK/birds_of_paradise.txt
@@ -1,0 +1,8 @@
+Name:Birds of Paradise
+ManaCost:no cost
+Colors:green
+Types:Creature Bird
+PT:0/1
+K:Flying
+A:AB$ Mana | Cost$ T | Produced$ Any | SpellDescription$ Add one mana of any color.
+Oracle:Flying\n{T}: Add one mana of any color.


### PR DESCRIPTION
## Summary
- script Utaman Bruiser, Challenger, Daring, Avatar of the Jungle, Barkskin Pummeler, Beastmaster's Tattoo, Caretaker of Paradise, Crowd of Kakamora, Haven of the Earth Gods, and Heart of the Gods
- add Birds of Paradise token script

## Testing
- `mvn -q -pl forge-gui -am test` *(fails: Unresolveable build extension org.apache.maven.wagon:wagon-ftp:3.5.3)*

------
https://chatgpt.com/codex/tasks/task_e_688acd3b2b548320b53ae1a976e4895c