### PR TITLE
Add RAK green card scripts

### DIFF
--- a/forge-gui/res/cardsfolder/RAK/heliha_steward_of_tua_rahi.txt
+++ b/forge-gui/res/cardsfolder/RAK/heliha_steward_of_tua_rahi.txt
@@ -5,6 +5,6 @@ PT:3/3
 K:Voyage
 A:AB$ Token | Cost$ W U B R G | TokenAmount$ 1 | TokenScript$ paradise | TokenOwner$ You | SpellDescription$ Voyage — Create Paradise, a legendary land token with hexproof and "{T}: Add one mana of any color."
 A:AB$ Mana | Cost$ T | Produced$ Any | SpellDescription$ Add one mana of any color.
-S:Mode$ AlternativeCost | ValidSA$ Spell | ValidPlayer$ You | Cost$ W U B R G | ConditionPresent$ Land.YouCtrl+namedParadise | Description$ As long as you control Paradise, you may pay {W}{U}{B}{R}{G} rather than pay the mana cost for spells that you cast.
+S:Mode$ AlternativeCost | ValidSA$ Spell | ValidPlayer$ You | Cost$ W U B R G | IsPresent$ Land.YouCtrl+namedParadise | PresentCompare$ GE1 | Description$ As long as you control Paradise, you may pay {W}{U}{B}{R}{G} rather than pay the mana cost for spells that you cast.
 SVar:NonStackingEffect:True
 Oracle:Voyage ({W}{U}{B}{R}{G}: Create Paradise, a legendary land token with hexproof and "{T}: Add one mana of any color.")\n{T}: Add one mana of any color.\nAs long as you control Paradise, you may pay {W}{U}{B}{R}{G} rather than pay the mana cost for spells that you cast.

--- a/forge-gui/res/cardsfolder/RAK/heliha_steward_of_tua_rahi.txt
+++ b/forge-gui/res/cardsfolder/RAK/heliha_steward_of_tua_rahi.txt
@@ -1,0 +1,10 @@
+Name:Heliha, Steward of Tua Rahi
+ManaCost:2 G
+Types:Legendary Creature Dryad Shaman
+PT:3/3
+K:Voyage
+A:AB$ Token | Cost$ W U B R G | TokenAmount$ 1 | TokenScript$ paradise | TokenOwner$ You | SpellDescription$ Voyage — Create Paradise, a legendary land token with hexproof and "{T}: Add one mana of any color."
+A:AB$ Mana | Cost$ T | Produced$ Any | SpellDescription$ Add one mana of any color.
+S:Mode$ AlternativeCost | ValidSA$ Spell | ValidPlayer$ You | Cost$ W U B R G | ConditionPresent$ Land.YouCtrl+namedParadise | Description$ As long as you control Paradise, you may pay {W}{U}{B}{R}{G} rather than pay the mana cost for spells that you cast.
+SVar:NonStackingEffect:True
+Oracle:Voyage ({W}{U}{B}{R}{G}: Create Paradise, a legendary land token with hexproof and "{T}: Add one mana of any color.")\n{T}: Add one mana of any color.\nAs long as you control Paradise, you may pay {W}{U}{B}{R}{G} rather than pay the mana cost for spells that you cast.

--- a/forge-gui/res/cardsfolder/RAK/heros_triumph.txt
+++ b/forge-gui/res/cardsfolder/RAK/heros_triumph.txt
@@ -1,0 +1,6 @@
+Name:Hero's Triumph
+ManaCost:1 G
+Types:Sorcery
+A:SP$ AddCounter | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | CounterType$ P1P1 | CounterNum$ 1 | ConditionPresent$ Forest.YouCtrl | ConditionCompare$ GE3 | SubAbility$ DBFight | SpellDescription$ Homeland — Put a +1/+1 counter on target creature you control if you control three or more Forests. Then that creature fights target creature you don't control.
+SVar:DBFight:DB$ Fight | Defined$ ParentTarget | ValidTgts$ Creature.YouDontCtrl | TgtPrompt$ Select target creature you don't control
+Oracle:Homeland — Put a +1/+1 counter on target creature you control if you control three or more Forests. Then that creature fights target creature you don't control.

--- a/forge-gui/res/cardsfolder/RAK/heros_triumph.txt
+++ b/forge-gui/res/cardsfolder/RAK/heros_triumph.txt
@@ -1,6 +1,6 @@
 Name:Hero's Triumph
 ManaCost:1 G
 Types:Sorcery
-A:SP$ AddCounter | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | CounterType$ P1P1 | CounterNum$ 1 | ConditionPresent$ Forest.YouCtrl | ConditionCompare$ GE3 | SubAbility$ DBFight | SpellDescription$ Homeland — Put a +1/+1 counter on target creature you control if you control three or more Forests. Then that creature fights target creature you don't control.
+A:SP$ PutCounter | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | CounterType$ P1P1 | CounterNum$ 1 | ConditionPresent$ Forest.YouCtrl | ConditionCompare$ GE3 | SubAbility$ DBFight | SpellDescription$ Homeland — Put a +1/+1 counter on target creature you control if you control three or more Forests. Then that creature fights target creature you don't control.
 SVar:DBFight:DB$ Fight | Defined$ ParentTarget | ValidTgts$ Creature.YouDontCtrl | TgtPrompt$ Select target creature you don't control
 Oracle:Homeland — Put a +1/+1 counter on target creature you control if you control three or more Forests. Then that creature fights target creature you don't control.

--- a/forge-gui/res/cardsfolder/RAK/hunters_technique.txt
+++ b/forge-gui/res/cardsfolder/RAK/hunters_technique.txt
@@ -1,0 +1,6 @@
+Name:Hunter's Technique
+ManaCost:2 G
+Types:Instant
+A:SP$ Pump | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | AddKeyword$ Indestructible | Duration$ EndOfTurn | SubAbility$ DBFight | SpellDescription$ Target creature you control gains indestructible until end of turn. It fights up to one target creature an opponent controls.
+SVar:DBFight:DB$ Fight | Defined$ ParentTarget | ValidTgts$ Creature.OppCtrl | TgtPrompt$ Select up to one target creature an opponent controls | TargetMin$ 0 | TargetMax$ 1
+Oracle:Target creature you control gains indestructible until end of turn. It fights up to one target creature an opponent controls.

--- a/forge-gui/res/cardsfolder/RAK/hunters_technique.txt
+++ b/forge-gui/res/cardsfolder/RAK/hunters_technique.txt
@@ -1,6 +1,6 @@
 Name:Hunter's Technique
 ManaCost:2 G
 Types:Instant
-A:SP$ Pump | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | AddKeyword$ Indestructible | Duration$ EndOfTurn | SubAbility$ DBFight | SpellDescription$ Target creature you control gains indestructible until end of turn. It fights up to one target creature an opponent controls.
+A:SP$ Pump | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | KW$ Indestructible | Duration$ EndOfTurn | SubAbility$ DBFight | SpellDescription$ Target creature you control gains indestructible until end of turn. It fights up to one target creature an opponent controls.
 SVar:DBFight:DB$ Fight | Defined$ ParentTarget | ValidTgts$ Creature.OppCtrl | TgtPrompt$ Select up to one target creature an opponent controls | TargetMin$ 0 | TargetMax$ 1
 Oracle:Target creature you control gains indestructible until end of turn. It fights up to one target creature an opponent controls.

--- a/forge-gui/res/cardsfolder/RAK/kalanuas_convert.txt
+++ b/forge-gui/res/cardsfolder/RAK/kalanuas_convert.txt
@@ -1,0 +1,6 @@
+Name:Kalanua's Convert
+ManaCost:1 G
+Types:Creature Dryad Shaman
+PT:2/2
+S:Mode$ Continuous | Affected$ Creature.Land+YouCtrl | AddPower$ 1 | AddToughness$ 1 | AddKeyword$ Ward:2 | Description$ Land creatures you control get +1/+1 and have ward {2}.
+Oracle:Land creatures you control get +1/+1 and have ward {2}. (Whenever one of those creatures becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)

--- a/forge-gui/res/cardsfolder/RAK/kalanuas_strength.txt
+++ b/forge-gui/res/cardsfolder/RAK/kalanuas_strength.txt
@@ -1,0 +1,6 @@
+Name:Kalanua's Strength
+ManaCost:1 G
+Types:Sorcery
+A:SP$ PutCounter | ValidTgts$ Permanent | TgtPrompt$ Select target permanent | CounterType$ P1P1 | CounterNum$ 2 | SpellDescription$ Put two +1/+1 counters on target permanent.
+K:Awaken:4:6 G
+Oracle:Put two +1/+1 counters on target permanent.\nAwaken 4—{6}{G} (If you cast this spell for {6}{G}, also put four +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)

--- a/forge-gui/res/cardsfolder/RAK/koheas_wisdom.txt
+++ b/forge-gui/res/cardsfolder/RAK/koheas_wisdom.txt
@@ -1,0 +1,7 @@
+Name:Kohea's Wisdom
+ManaCost:2 G
+Types:Sorcery
+A:SP$ ChangeZone | Origin$ Graveyard | Destination$ Hand | ValidTgts$ Card.YouCtrl | TgtPrompt$ Select target card in your graveyard | SubAbility$ DBExile | SpellDescription$ Return target card from your graveyard to your hand. Exile CARDNAME.
+SVar:DBExile:DB$ ChangeZone | Origin$ Stack | Destination$ Exile
+K:Awaken:4:5 G
+Oracle:Return target card from your graveyard to your hand. Exile Kohea's Wisdom.\nAwaken 4—{5}{G} (If you cast this spell for {5}{G}, also put four +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)

--- a/forge-gui/res/cardsfolder/RAK/leafy_companion.txt
+++ b/forge-gui/res/cardsfolder/RAK/leafy_companion.txt
@@ -1,0 +1,7 @@
+Name:Leafy Companion
+ManaCost:2 G
+Types:Creature Plant Dog
+PT:2/3
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | OptionalDecider$ You | Execute$ TrigSearch | TriggerDescription$ When CARDNAME enters the battlefield, you may search your library for a Forest card, reveal it, put it into your hand, then shuffle.
+SVar:TrigSearch:DB$ ChangeZone | Origin$ Library | Destination$ Hand | ChangeType$ Forest | ChangeNum$ 1 | ShuffleNonMandatory$ True
+Oracle:When Leafy Companion enters the battlefield, you may search your library for a Forest card, reveal it, put it into your hand, then shuffle.

--- a/forge-gui/res/cardsfolder/RAK/luaho_commune.txt
+++ b/forge-gui/res/cardsfolder/RAK/luaho_commune.txt
@@ -1,0 +1,5 @@
+Name:Luaho Commune
+ManaCost:1 G
+Types:Sorcery
+A:SP$ DigMultiple | DigNum$ 5 | Reveal$ True | ChangeValid$ Land,Aura | Optional$ True | RestRandomOrder$ True | ForceRevealToController$ True | SpellDescription$ Look at the top five cards of your library. Reveal up to one land card and up to one Aura card from among them, put those cards into your hand, then put the rest on the bottom of your library in a random order.
+Oracle:Look at the top five cards of your library. Reveal up to one land card and up to one Aura card from among them, put those cards into your hand, then put the rest on the bottom of your library in a random order.

--- a/forge-gui/res/cardsfolder/RAK/luaho_feather-worker.txt
+++ b/forge-gui/res/cardsfolder/RAK/luaho_feather-worker.txt
@@ -1,0 +1,8 @@
+Name:Luaho Feather-Worker
+ManaCost:1 G
+Types:Creature Elf Shaman
+PT:2/2
+K:Voyage
+A:AB$ Token | Cost$ W U B R G | TokenAmount$ 1 | TokenScript$ paradise | TokenOwner$ You | SpellDescription$ Voyage — Create Paradise, a legendary land token with hexproof and "{T}: Add one mana of any color."
+S:Mode$ Continuous | Affected$ Card.Self | AddPower$ 2 | AddToughness$ 2 | IsPresent$ Land.YouCtrl+namedParadise | PresentCompare$ GE1 | Description$ As long as you control Paradise, CARDNAME gets +2/+2.
+Oracle:Voyage ({W}{U}{B}{R}{G}: Create Paradise, a legendary land token with hexproof and "{T}: Add one mana of any color.")\nAs long as you control Paradise, Luaho Feather-Worker gets +2/+2.

--- a/forge-gui/res/cardsfolder/RAK/luaho_lorekeeper.txt
+++ b/forge-gui/res/cardsfolder/RAK/luaho_lorekeeper.txt
@@ -1,0 +1,7 @@
+Name:Luaho Lorekeeper
+ManaCost:3 G
+Types:Creature Dryad Shaman
+PT:3/3
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | IsPresent$ Forest.YouCtrl | PresentCompare$ GE3 | Execute$ TrigDraw | TriggerDescription$ Homeland — When CARDNAME enters the battlefield, if you control three or more Forests, draw a card.
+SVar:TrigDraw:DB$ Draw | Defined$ You | NumCards$ 1
+Oracle:Homeland — When Luaho Lorekeeper enters the battlefield, if you control three or more Forests, draw a card.


### PR DESCRIPTION
## Summary
- script Heliha, Steward of Tua Rahi with Voyage and alternative WUBRG cost
- add several green sorceries and creatures for RAK set, including Homeland, Awaken, and Voyage abilities
- implement supporting search, fight, and counter interactions

## Testing
- `mvn -q -pl forge-gui-desktop test` *(fails: Unresolveable build extension org.apache.maven.wagon:wagon-ftp:3.5.3)*

------
https://chatgpt.com/codex/tasks/task_e_688ad05e8aa08320999d5a9d84119af2