### PR TITLE
Add custom RAK green card scripts

### DIFF
--- a/forge-gui/res/cardsfolder/RAK/luaho_trackers.txt
+++ b/forge-gui/res/cardsfolder/RAK/luaho_trackers.txt
@@ -1,0 +1,8 @@
+Name:Luaho Trackers
+ManaCost:2 G G
+Types:Creature Human Scout
+PT:4/4
+K:Trample
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigSearch | TriggerDescription$ When CARDNAME enters, search your library for a green creature card, reveal it, then shuffle and put that card on top.
+SVar:TrigSearch:DB$ ChangeZone | Origin$ Library | Destination$ Library | LibraryPosition$ 0 | ChangeType$ Creature.Green | ChangeNum$ 1 | Shuffle$ True
+Oracle:Trample\nWhen Luaho Trackers enters, search your library for a green creature card, reveal it, then shuffle and put that card on top.

--- a/forge-gui/res/cardsfolder/RAK/monument_core.txt
+++ b/forge-gui/res/cardsfolder/RAK/monument_core.txt
@@ -1,0 +1,10 @@
+Name:Monument Core
+ManaCost:2 G
+Types:Enchantment Aura
+K:Enchant:Land
+SVar:AttachAILogic:Pump
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters, create two Treasure tokens.
+SVar:TrigToken:DB$ Token | TokenAmount$ 2 | TokenScript$ c_a_treasure_sac | TokenOwner$ You
+S:Mode$ Continuous | Affected$ Card.EnchantedBy | AddAbility$ MCAttack | Description$ Enchanted land has "{2}{G}, {T}: Put a +1/+1 counter on target creature you control. Activate only as a sorcery."
+SVar:MCAttack:AB$ PutCounter | Cost$ 2 G T | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | CounterType$ P1P1 | CounterNum$ 1 | SorcerySpeed$ True | SpellDescription$ Put a +1/+1 counter on target creature you control. Activate only as a sorcery.
+Oracle:Enchant land\nWhen Monument Core enters, create two Treasure tokens. (They're artifacts with "{T}, Sacrifice this artifact: Add one mana of any color.")\nEnchanted land has "{2}{G}, {T}: Put a +1/+1 counter on target creature you control. Activate only as a sorcery."

--- a/forge-gui/res/cardsfolder/RAK/opaku_warden.txt
+++ b/forge-gui/res/cardsfolder/RAK/opaku_warden.txt
@@ -1,0 +1,8 @@
+Name:Opaku Warden
+ManaCost:1 G
+Types:Creature Elf Archer
+PT:3/2
+K:Reach
+T:Mode$ Attacks | ValidCard$ Card.Self | OptionalDecider$ You | Execute$ TrigPump | TriggerDescription$ Whenever CARDNAME attacks, you may pay {1}{G}. If you do, CARDNAME gets +2/+2 until end of turn.
+SVar:TrigPump:AB$ Pump | Cost$ 1 G | Defined$ Self | NumAtt$ 2 | NumDef$ 2 | SpellDescription$ CARDNAME gets +2/+2 until end of turn.
+Oracle:Reach\nWhenever Opaku Warden attacks, you may pay {1}{G}. If you do, Opaku Warden gets +2/+2 until end of turn.

--- a/forge-gui/res/cardsfolder/RAK/patron_mo-o.txt
+++ b/forge-gui/res/cardsfolder/RAK/patron_mo-o.txt
@@ -1,0 +1,8 @@
+Name:Patron Mo-o
+ManaCost:2 G
+Types:Creature Elemental Lizard
+PT:3/3
+T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigSurveil | TriggerDescription$ Whenever CARDNAME attacks, surveil 1. (Look at the top card of your library. You may put that card into your graveyard.)
+SVar:TrigSurveil:DB$ Surveil | Amount$ 1
+A:AB$ ChangeZone | Cost$ 1 G | ActivationZone$ Graveyard | Origin$ Graveyard | Destination$ Battlefield | Tapped$ True | FaceDown$ True | FaceDownSetType$ Land | SpellDescription$ Return CARDNAME from your graveyard to the battlefield face down and tapped. It's a colorless land with "{T}: Add {C}."
+Oracle:Whenever Patron Mo-o attacks, look at the top card of your library. You may put that card into your graveyard.\n{1}{G}: Return Patron Mo-o from your graveyard to the battlefield face down and tapped. It's a colorless land with "{T}: Add {C}."

--- a/forge-gui/res/cardsfolder/RAK/primal_reaction.txt
+++ b/forge-gui/res/cardsfolder/RAK/primal_reaction.txt
@@ -1,0 +1,7 @@
+Name:Primal Reaction
+ManaCost:2 G
+Types:Instant
+A:SP$ Charm | Choices$ DBPump,DBDestroy
+SVar:DBPump:DB$ Pump | ValidTgts$ Creature | NumAtt$ 4 | NumDef$ 4 | TgtPrompt$ Select target creature | SpellDescription$ Target creature gets +4/+4 until end of turn.
+SVar:DBDestroy:DB$ Destroy | ValidTgts$ Creature.Flying | TgtPrompt$ Select target creature with flying | SpellDescription$ Destroy target creature with flying.
+Oracle:Choose one —\n• Target creature gets +4/+4 until end of turn.\n• Destroy target creature with flying.

--- a/forge-gui/res/cardsfolder/RAK/speaker_for_the_kakamora.txt
+++ b/forge-gui/res/cardsfolder/RAK/speaker_for_the_kakamora.txt
@@ -1,0 +1,9 @@
+Name:Speaker for the Kakamora
+ManaCost:G
+Types:Creature Elf Shaman
+PT:1/1
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigScry | TriggerDescription$ When CARDNAME enters, scry 2.
+SVar:TrigScry:DB$ Scry | ScryNum$ 2
+A:AB$ Mana | Cost$ T | Produced$ G | ConditionCheckSVar$ Forests | ConditionSVarCompare$ GE3 | SpellDescription$ Add {G}. Activate only if you control three or more Forests.
+SVar:Forests:Count$Valid Forest.YouCtrl
+Oracle:When Speaker for the Kakamora enters, scry 2.\nHomeland — {T}: Add {G}. Activate only if you control three or more Forests.

--- a/forge-gui/res/cardsfolder/RAK/tua_rahi_snapdragon.txt
+++ b/forge-gui/res/cardsfolder/RAK/tua_rahi_snapdragon.txt
@@ -1,0 +1,9 @@
+Name:Tua Rahi Snapdragon
+ManaCost:2 G
+Types:Creature Plant Snake
+PT:2/3
+K:Hexproof
+K:Voyage
+A:AB$ Token | Cost$ W U B R G | TokenAmount$ 1 | TokenScript$ paradise | TokenOwner$ You | SpellDescription$ Voyage — Create Paradise, a legendary land token with hexproof and "{T}: Add one mana of any color."
+S:Mode$ Continuous | Affected$ Card.Self | AddPower$ 1 | AddToughness$ 1 | AddKeyword$ Deathtouch | IsPresent$ Land.YouCtrl+namedParadise | PresentCompare$ GE1 | Description$ As long as you control Paradise, CARDNAME gets +1/+1 and has deathtouch.
+Oracle:Hexproof\nVoyage ({W}{U}{B}{R}{G}: Create Paradise, a legendary land token with hexproof and "{T}: Add one mana of any color.")\nAs long as you control Paradise, Tua Rahi Snapdragon gets +1/+1 and has deathtouch.

--- a/forge-gui/res/cardsfolder/RAK/unassuming_duwende.txt
+++ b/forge-gui/res/cardsfolder/RAK/unassuming_duwende.txt
@@ -1,0 +1,6 @@
+Name:Unassuming Duwende
+ManaCost:G
+Types:Creature Ouphe
+PT:1/1
+A:AB$ PutCounter | Cost$ 2 G ExileFromGrave<1/Card> | Defined$ Self | CounterType$ P1P1 | CounterNum$ 1 | SpellDescription$ Put a +1/+1 counter on CARDNAME.
+Oracle:{2}{G}, Exile a card from your graveyard: Put a +1/+1 counter on Unassuming Duwende.

--- a/forge-gui/res/cardsfolder/RAK/unwieldy_catch.txt
+++ b/forge-gui/res/cardsfolder/RAK/unwieldy_catch.txt
@@ -1,0 +1,10 @@
+Name:Unwieldy Catch
+ManaCost:2 G
+Types:Sorcery
+A:SP$ Dig | DigNum$ 6 | Optional$ True | ChangeValid$ Creature | DestinationZone$ Exile | RememberChanged$ True | ForceRevealToController$ True | SubAbility$ DBChoose | SpellDescription$ Look at the top six cards of your library. You may exile a creature card from among them. If you do, any opponent may have you put that card onto the battlefield. If no player does, you draw three cards.
+SVar:DBChoose:DB$ GenericChoice | Defined$ Opponent | Choices$ DBToBattlefield,DoNothing | ChoicePrompt$ Have them put that card onto the battlefield? | ConditionDefined$ Remembered | ConditionZone$ Exile | ConditionPresent$ Card | ConditionCompare$ EQ1 | SubAbility$ DBDraw
+SVar:DBToBattlefield:DB$ ChangeZone | Origin$ Exile | Destination$ Battlefield | Defined$ Remembered | SpellDescription$ Yes
+SVar:DoNothing:DB$ Cleanup | SpellDescription$ No
+SVar:DBDraw:DB$ Draw | NumCards$ 3 | ConditionDefined$ Remembered | ConditionZone$ Exile | ConditionPresent$ Card | ConditionCompare$ GE1 | SubAbility$ DBCleanup | StackDescription$ None
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+Oracle:Look at the top six cards of your library. You may exile a creature card from among them. If you do, any opponent may have you put that card onto the battlefield. If no player does, you draw three cards.

--- a/forge-gui/res/cardsfolder/RAK/verdant_extent.txt
+++ b/forge-gui/res/cardsfolder/RAK/verdant_extent.txt
@@ -1,0 +1,10 @@
+Name:Verdant Extent
+ManaCost:1 G
+Types:Enchantment Aura
+K:Enchant:Land
+SVar:AttachAILogic:Pump
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | OptionalDecider$ You | Execute$ TrigSearch | TriggerDescription$ When CARDNAME enters, you may search your library for a Forest card, reveal it, put it into your hand, then shuffle.
+SVar:TrigSearch:DB$ ChangeZone | Origin$ Library | Destination$ Hand | ChangeType$ Card.Forest | ChangeNum$ 1 | ShuffleNonMandatory$ True
+S:Mode$ Continuous | Affected$ Card.EnchantedBy | AddAbility$ VEMana | Description$ Enchanted land has "{G}, {T}: Target creature gets +3/+3 until end of turn. Activate only as a sorcery."
+SVar:VEMana:AB$ Pump | Cost$ G T | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | NumAtt$ 3 | NumDef$ 3 | SorcerySpeed$ True | SpellDescription$ Target creature gets +3/+3 until end of turn. Activate only as a sorcery.
+Oracle:Enchant land\nWhen Verdant Extent enters, you may search your library for a Forest card, reveal it, put it into your hand, then shuffle.\nEnchanted land has "{G}, {T}: Target creature gets +3/+3 until end of turn. Activate only as a sorcery."


### PR DESCRIPTION
## Summary
- script Luaho Trackers
- script Monument Core, Opaku Warden, Patron Mo-o
- script Primal Reaction, Speaker for the Kakamora, Tua Rahi Snapdragon
- script Unassuming Duwende, Unwieldy Catch, Verdant Extent
- use newline escapes in oracle text for the above cards

## Testing
- `mvn -q -pl forge-gui -am test` *(fails: Unresolveable build extension org.apache.maven.wagon:wagon-ftp:3.5.3)*

------
https://chatgpt.com/codex/tasks/task_e_688ad3dcbcd4832080eb59c747d14fb8