### PR TITLE
Add RAK custom card scripts

### DIFF
--- a/forge-gui/res/cardsfolder/RAK/gilded_adarna.txt
+++ b/forge-gui/res/cardsfolder/RAK/gilded_adarna.txt
@@ -1,0 +1,13 @@
+Name:Gilded Adarna
+ManaCost:RG RW UR BR
+Types:Creature Phoenix
+PT:3/3
+K:Flying
+K:Trample
+T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Opponent | CombatDamage$ True | Execute$ TrigToken | TriggerDescription$ Whenever CARDNAME deals combat damage to an opponent, create that many Treasure tokens.
+SVar:TrigToken:DB$ Token | TokenAmount$ X | TokenScript$ c_a_treasure_sac | TokenOwner$ You
+SVar:X:TriggerCount$DamageAmount
+A:AB$ ChangeZone | Cost$ W U B R G | Origin$ Graveyard | Destination$ Hand | ActivationZone$ Graveyard | SpellDescription$ Return CARDNAME from your graveyard to your hand.
+SVar:PlayMain1:TRUE
+DeckHas:Ability$Token & Type$Treasure|Artifact
+Oracle:Flying, trample\nWhenever Gilded Adarna deals combat damage to an opponent, create that many Treasure tokens.\n{W}{U}{B}{R}{G}: Return Gilded Adarna from your graveyard to your hand.

--- a/forge-gui/res/cardsfolder/RAK/kelp_chimera.txt
+++ b/forge-gui/res/cardsfolder/RAK/kelp_chimera.txt
@@ -1,5 +1,5 @@
 Name:Kelp Chimera
-ManaCost:GW UG BG RG
+ManaCost:GW GU BG RG
 Types:Creature Chimera
 PT:5/5
 K:Vigilance

--- a/forge-gui/res/cardsfolder/RAK/kelp_chimera.txt
+++ b/forge-gui/res/cardsfolder/RAK/kelp_chimera.txt
@@ -1,0 +1,15 @@
+Name:Kelp Chimera
+ManaCost:GW UG BG RG
+Types:Creature Chimera
+PT:5/5
+K:Vigilance
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ DBTrigger | TriggerDescription$ When CARDNAME enters, you may sacrifice another creature. When you do, CARDNAME deals damage to target creature an opponent controls equal to the sacrificed creature's power and you gain life equal to the sacrificed creature's toughness.
+SVar:DBTrigger:AB$ ImmediateTrigger | Cost$ Sac<1/Creature.Other/another creature> | Execute$ TrigDamage | AILogic$ SacForDamage | TriggerDescription$ When you do, CARDNAME deals damage to target creature an opponent controls equal to the sacrificed creature's power and you gain life equal to the sacrificed creature's toughness.
+SVar:TrigDamage:DB$ DealDamage | ValidTgts$ Creature.OppCtrl | TgtPrompt$ Select target creature an opponent controls | NumDmg$ XPower | SubAbility$ DBGainLife
+SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ YTough
+SVar:XPower:Spawner>Sacrificed$CardPower
+SVar:YTough:Spawner>Sacrificed$CardToughness
+SVar:AIPreferenceParams:CreatureEvalThreshold$ 200
+SVar:PlayMain1:TRUE
+DeckHas:Ability$Sacrifice
+Oracle:Vigilance\nWhen Kelp Chimera enters the battlefield, you may sacrifice another creature. When you do, Kelp Chimera deals damage to target creature an opponent controls equal to the sacrificed creature's power and you gain life equal to the sacrificed creature's toughness.

--- a/forge-gui/res/cardsfolder/RAK/long_spear_instructor.txt
+++ b/forge-gui/res/cardsfolder/RAK/long_spear_instructor.txt
@@ -1,0 +1,10 @@
+Name:Long-Spear Instructor
+ManaCost:RW RW RW RW
+Types:Creature Human Scout
+PT:3/3
+K:First Strike
+T:Mode$ Phase | Phase$ BeginCombat | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigPump | TriggerDescription$ At the beginning of combat on your turn, another target creature you control gets +2/+0 and gains first strike until end of turn.
+SVar:TrigPump:DB$ Pump | ValidTgts$ Creature.YouCtrl+Other | TgtPrompt$ Select another target creature you control | NumAtt$ +2 | KW$ First Strike
+SVar:PlayMain1:TRUE
+DeckHas:Ability$Pump
+Oracle:First strike\nAt the beginning of combat on your turn, another target creature you control gets +2/+0 and gains first strike until end of turn.

--- a/forge-gui/res/cardsfolder/RAK/rahokes_ruiner.txt
+++ b/forge-gui/res/cardsfolder/RAK/rahokes_ruiner.txt
@@ -1,0 +1,10 @@
+Name:Rahoke's Ruiner
+ManaCost:BR BR BR BR
+Types:Creature Elemental Demon
+PT:6/6
+K:Menace
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigSac | TriggerDescription$ When CARDNAME enters, sacrifice a creature.
+SVar:TrigSac:DB$ Sacrifice | SacValid$ Creature.YouCtrl
+SVar:PlayMain1:TRUE
+DeckHas:Ability$Sacrifice
+Oracle:Menace\nWhen Rahoke's Ruiner enters the battlefield, sacrifice a creature.

--- a/forge-gui/res/cardsfolder/RAK/rekos_protege.txt
+++ b/forge-gui/res/cardsfolder/RAK/rekos_protege.txt
@@ -1,0 +1,9 @@
+Name:Reko's Protege
+ManaCost:2 RW
+Types:Creature Human Warrior
+PT:3/2
+T:Mode$ Attacks | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigPump | TriggerDescription$ Whenever CARDNAME attacks, it gets +1/+1 until end of turn.
+SVar:TrigPump:DB$ Pump | Defined$ Self | NumAtt$ +1 | NumDef$ +1
+SVar:PlayMain1:TRUE
+DeckHas:Ability$Pump
+Oracle:Whenever Reko's Protege attacks, it gets +1/+1 until end of turn.

--- a/forge-gui/res/cardsfolder/RAK/ru_kano_scavengers.txt
+++ b/forge-gui/res/cardsfolder/RAK/ru_kano_scavengers.txt
@@ -1,0 +1,8 @@
+Name:Ru Kano Scavengers
+ManaCost:BG BG BG BG
+Types:Creature Crab
+PT:4/4
+A:AB$ PutCounter | Cost$ BG BG BG BG ExileFromGrave<1/CARDNAME> | ActivationZone$ Graveyard | ValidTgts$ Creature | TgtPrompt$ Select target creature | CounterType$ P1P1 | CounterNum$ 4 | SorcerySpeed$ True | SpellDescription$ Put four +1/+1 counters on target creature. Activate only as a sorcery.
+SVar:PlayMain1:TRUE
+DeckHas:Ability$Counters
+Oracle:{B/G}{B/G}{B/G}{B/G}, Exile Ru Kano Scavengers from your graveyard: Put four +1/+1 counters on target creature. Activate only as a sorcery.

--- a/forge-gui/res/cardsfolder/RAK/seeding_frenzy.txt
+++ b/forge-gui/res/cardsfolder/RAK/seeding_frenzy.txt
@@ -1,0 +1,7 @@
+Name:Seeding Frenzy
+ManaCost:3 WU
+Types:Instant
+A:SP$ Token | TokenAmount$ 2 | TokenScript$ u_1_1_bird_flying | TokenOwner$ You | SubAbility$ DBScry | SpellDescription$ Create two 1/1 blue Bird creature tokens with flying. Scry 2.
+SVar:DBScry:DB$ Scry | ScryNum$ 2
+DeckHas:Ability$Token & Type$Bird|Creature
+Oracle:Create two 1/1 blue Bird creature tokens with flying. Scry 2.

--- a/forge-gui/res/cardsfolder/RAK/shrewd_aristocrat.txt
+++ b/forge-gui/res/cardsfolder/RAK/shrewd_aristocrat.txt
@@ -1,0 +1,11 @@
+Name:Shrewd Aristocrat
+ManaCost:WB WB WB WB
+Types:Creature Human Noble
+PT:3/4
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigGainLife | TriggerDescription$ When CARDNAME enters, you gain 3 life.
+SVar:TrigGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 3
+A:AB$ RepeatEach | Cost$ T | RepeatPlayers$ Player | SubAbility$ DBPayDraw | SpellDescription$ Each player may pay 3 life. Each player that does draws a card.
+SVar:DBPayDraw:DB$ Draw | Defined$ Player.IsRemembered | NumCards$ 1 | UnlessCost$ PayLife<3> | UnlessPayer$ Player.IsRemembered | UnlessSwitched$ True
+SVar:PlayMain1:TRUE
+DeckHas:Ability$Draw
+Oracle:When Shrewd Aristocrat enters the battlefield, you gain 3 life.\n{T}: Each player may pay 3 life. Each player that does draws a card.

--- a/forge-gui/res/cardsfolder/RAK/shrewd_aristocrat.txt
+++ b/forge-gui/res/cardsfolder/RAK/shrewd_aristocrat.txt
@@ -4,7 +4,7 @@ Types:Creature Human Noble
 PT:3/4
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigGainLife | TriggerDescription$ When CARDNAME enters, you gain 3 life.
 SVar:TrigGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 3
-A:AB$ RepeatEach | Cost$ T | RepeatPlayers$ Player | SubAbility$ DBPayDraw | SpellDescription$ Each player may pay 3 life. Each player that does draws a card.
+A:AB$ RepeatEach | Cost$ T | RepeatPlayers$ Player | RepeatSubAbility$ DBPayDraw | SpellDescription$ Each player may pay 3 life. Each player that does draws a card.
 SVar:DBPayDraw:DB$ Draw | Defined$ Player.IsRemembered | NumCards$ 1 | UnlessCost$ PayLife<3> | UnlessPayer$ Player.IsRemembered | UnlessSwitched$ True
 SVar:PlayMain1:TRUE
 DeckHas:Ability$Draw

--- a/forge-gui/res/cardsfolder/RAK/solitary_survivor.txt
+++ b/forge-gui/res/cardsfolder/RAK/solitary_survivor.txt
@@ -1,0 +1,12 @@
+Name:Solitary Survivor
+ManaCost:WU WB RW GW
+Types:Creature Whale Warrior
+PT:4/4
+T:Mode$ AttackerBlocked | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigDamage | TriggerDescription$ Whenever CARDNAME becomes blocked by one or more creatures, it deals damage equal to its toughness to target creature blocking it and you gain that much life.
+SVar:TrigDamage:DB$ DealDamage | ValidTgts$ Creature.blockingSource | TgtPrompt$ Select target creature blocking CARDNAME | NumDmg$ X | SubAbility$ DBGainLife
+SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ X
+SVar:X:Count$CardToughness
+A:AB$ Pump | Cost$ 1 | Defined$ Self | NumAtt$ -1 | NumDef$ +1 | SpellDescription$ CARDNAME gets -1/+1 until end of turn.
+SVar:PlayMain1:TRUE
+DeckHas:Ability$Pump
+Oracle:Whenever Solitary Survivor becomes blocked by one or more creatures, it deals damage equal to its toughness to target creature blocking it and you gain that much life.\n{1}: Solitary Survivor gets -1/+1 until end of turn.

--- a/forge-gui/res/cardsfolder/RAK/surfstream_cruiser.txt
+++ b/forge-gui/res/cardsfolder/RAK/surfstream_cruiser.txt
@@ -1,0 +1,11 @@
+Name:Surfstream Cruiser
+ManaCost:UB UR GU WU
+Types:Creature Human Shaman Turtle
+PT:2/5
+K:Haste
+K:Defender
+A:AB$ Dig | Cost$ T | DigNum$ 1 | ChangeNum$ 1 | ChangeValid$ Card.cmcLE2 | DestinationZone$ Hand | DestinationZone2$ Graveyard | Optional$ True | Reveal$ True | SpellDescription$ Look at the top card of your library. If it has mana value 2 or less, you may reveal it and put it into your hand. Otherwise, put it into your graveyard.
+T:Mode$ SpellCast | ValidCard$ Card | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigUntap | TriggerDescription$ Whenever you cast a spell, untap CARDNAME.
+SVar:TrigUntap:DB$ Untap | Defined$ Self
+SVar:PlayMain1:TRUE
+Oracle:Haste, defender\n{T}: Look at the top card of your library. If it has mana value 2 or less, you may reveal it and put it into your hand. Otherwise, put it into your graveyard.\nWhenever you cast a spell, untap Surfstream Cruiser.


### PR DESCRIPTION
## Summary
- add Gilded Adarna with Treasure token generation and graveyard recursion
- add Kelp Chimera etb sacrifice for damage and life gain
- script additional RAK cards including Long-Spear Instructor, Rahoke's Ruiner, Reko's Protege, Ru Kano Scavengers, Seeding Frenzy, Shrewd Aristocrat, Solitary Survivor, and Surfstream Cruiser

## Testing
- `mvn -q test` *(fails: Unresolveable build extension org.apache.maven.wagon:wagon-ftp:jar:3.5.3)*

------
https://chatgpt.com/codex/tasks/task_e_688adab6b1c48320b91781d0729ff4fb