### PR TITLE
Add custom RAK cards

### DIFF
--- a/forge-gui/res/cardsfolder/RAK/echoshells.txt
+++ b/forge-gui/res/cardsfolder/RAK/echoshells.txt
@@ -1,0 +1,6 @@
+Name:Echoshells
+ManaCost:3
+Types:Artifact
+A:AB$ ManaReflected | Cost$ T | ColorOrType$ Type | Valid$ Land.YouCtrl | ReflectProperty$ Produce | SpellDescription$ Add one mana of any type that a land you control could produce.
+A:AB$ ChangeZone | Cost$ 1 T Sac<1/CARDNAME> | Origin$ Library | Destination$ Battlefield | Tapped$ True | ChangeType$ Land | ChangeNum$ 1 | SpellDescription$ Search your library for a land card, put it onto the battlefield tapped, then shuffle.
+Oracle:{T}: Add one mana of any type that a land you control could produce.\n{1}, {T}, Sacrifice Echoshells: Search your library for a land card, put it onto the battlefield tapped, then shuffle.

--- a/forge-gui/res/cardsfolder/RAK/engraved_moai.txt
+++ b/forge-gui/res/cardsfolder/RAK/engraved_moai.txt
@@ -4,5 +4,6 @@ Types:Artifact
 K:Voyage
 A:AB$ Token | Cost$ W U B R G | TokenAmount$ 1 | TokenScript$ paradise | TokenOwner$ You | SpellDescription$ Voyage — Create Paradise, a legendary land token with hexproof and "{T}: Add one mana of any color."
 A:AB$ Mana | Cost$ T | Produced$ Any | SpellDescription$ Add one mana of any color.
-A:AB$ Tap | Cost$ 3 T | ValidTgts$ Creature | TgtPrompt$ Select target creature | ConditionPresent$ Land.YouCtrl+namedParadise | ConditionCompare$ GE1 | SpellDescription$ Tap target creature. Activate only if you control Paradise.
+A:AB$ Tap | Cost$ 3 T | ValidTgts$ Creature | TgtPrompt$ Select target creature | CheckSVar$ X | SVarCompare$ GE1 | SpellDescription$ Tap target creature. Activate only if you control Paradise.
+SVar:X:Count$Valid Land.YouCtrl+namedParadise
 Oracle:Voyage ({W}{U}{B}{R}{G}: Create Paradise, a legendary land token with hexproof and "{T}: Add one mana of any color.")\n{T}: Add one mana of any color.\n{3}, {T}: Tap target creature. Activate only if you control Paradise.

--- a/forge-gui/res/cardsfolder/RAK/engraved_moai.txt
+++ b/forge-gui/res/cardsfolder/RAK/engraved_moai.txt
@@ -1,0 +1,8 @@
+Name:Engraved Moai
+ManaCost:3
+Types:Artifact
+K:Voyage
+A:AB$ Token | Cost$ W U B R G | TokenAmount$ 1 | TokenScript$ paradise | TokenOwner$ You | SpellDescription$ Voyage — Create Paradise, a legendary land token with hexproof and "{T}: Add one mana of any color."
+A:AB$ Mana | Cost$ T | Produced$ Any | SpellDescription$ Add one mana of any color.
+A:AB$ Tap | Cost$ 3 T | ValidTgts$ Creature | TgtPrompt$ Select target creature | ConditionPresent$ Land.YouCtrl+namedParadise | ConditionCompare$ GE1 | SpellDescription$ Tap target creature. Activate only if you control Paradise.
+Oracle:Voyage ({W}{U}{B}{R}{G}: Create Paradise, a legendary land token with hexproof and "{T}: Add one mana of any color.")\n{T}: Add one mana of any color.\n{3}, {T}: Tap target creature. Activate only if you control Paradise.

--- a/forge-gui/res/cardsfolder/RAK/homebound_kaulua.txt
+++ b/forge-gui/res/cardsfolder/RAK/homebound_kaulua.txt
@@ -1,0 +1,9 @@
+Name:Homebound Kaulua
+ManaCost:2
+Types:Artifact Vehicle
+PT:4/4
+K:Haste
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Land.Basic+YouCtrl | TriggerZones$ Battlefield | Execute$ TrigAnimate | TriggerDescription$ Whenever a basic land enters the battlefield under your control, CARDNAME becomes an artifact creature until end of turn.
+SVar:TrigAnimate:DB$ Animate | Defined$ Self | Types$ Artifact,Creature | SpellDescription$ CARDNAME becomes an artifact creature until end of turn.
+K:Crew:2
+Oracle:Haste\nWhenever a basic land enters the battlefield under your control, Homebound Kaulua becomes an artifact creature until end of turn.\nCrew 2 (Tap any number of creatures you control with total power 2 or greater: This Vehicle becomes an artifact creature until end of turn.)

--- a/forge-gui/res/cardsfolder/RAK/pearlescent_egg.txt
+++ b/forge-gui/res/cardsfolder/RAK/pearlescent_egg.txt
@@ -5,7 +5,7 @@ K:Voyage
 A:AB$ Token | Cost$ W U B R G | TokenAmount$ 1 | TokenScript$ paradise | TokenOwner$ You | SpellDescription$ Voyage — Create Paradise, a legendary land token with hexproof and "{T}: Add one mana of any color."
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigDraw | TriggerDescription$ When CARDNAME enters the battlefield, draw a card.
 SVar:TrigDraw:DB$ Draw | NumCards$ 1
-A:AB$ Mana | Cost$ 1 T | Produced$ Any | Amount$ ManaAmount | SpellDescription$ Add one mana of any color. If you control Paradise, add two mana in any combination of colors instead.
+A:AB$ Mana | Cost$ 1 T | Produced$ Combo Any | Amount$ ManaAmount | SpellDescription$ Add one mana of any color. If you control Paradise, add two mana in any combination of colors instead.
 SVar:HasParadise:Count$Valid Land.YouCtrl+namedParadise
 SVar:ManaAmount:Count$Compare HasParadise GE1.2.1
 Oracle:Voyage ({W}{U}{B}{R}{G}: Create Paradise, a legendary land token with hexproof and "{T}: Add one mana of any color.")\nWhen Pearlescent Egg enters the battlefield, draw a card.\n{1}, {T}: Add one mana of any color. If you control Paradise, add two mana in any combination of colors instead.

--- a/forge-gui/res/cardsfolder/RAK/pearlescent_egg.txt
+++ b/forge-gui/res/cardsfolder/RAK/pearlescent_egg.txt
@@ -1,0 +1,11 @@
+Name:Pearlescent Egg
+ManaCost:2
+Types:Artifact
+K:Voyage
+A:AB$ Token | Cost$ W U B R G | TokenAmount$ 1 | TokenScript$ paradise | TokenOwner$ You | SpellDescription$ Voyage — Create Paradise, a legendary land token with hexproof and "{T}: Add one mana of any color."
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigDraw | TriggerDescription$ When CARDNAME enters the battlefield, draw a card.
+SVar:TrigDraw:DB$ Draw | NumCards$ 1
+A:AB$ Mana | Cost$ 1 T | Produced$ Any | Amount$ ManaAmount | SpellDescription$ Add one mana of any color. If you control Paradise, add two mana in any combination of colors instead.
+SVar:HasParadise:Count$Valid Land.YouCtrl+namedParadise
+SVar:ManaAmount:Count$Compare HasParadise GE1.2.1
+Oracle:Voyage ({W}{U}{B}{R}{G}: Create Paradise, a legendary land token with hexproof and "{T}: Add one mana of any color.")\nWhen Pearlescent Egg enters the battlefield, draw a card.\n{1}, {T}: Add one mana of any color. If you control Paradise, add two mana in any combination of colors instead.

--- a/forge-gui/res/cardsfolder/RAK/pounamu_keepsake.txt
+++ b/forge-gui/res/cardsfolder/RAK/pounamu_keepsake.txt
@@ -1,0 +1,8 @@
+Name:Pounamu Keepsake
+ManaCost:2
+Types:Artifact Equipment
+S:Mode$ Continuous | Affected$ Creature.EquippedBy | AddPower$ 2 | Description$ Equipped creature gets +2/+0.
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Any | ValidCard$ Creature.EquippedBy | OptionalDecider$ You | Execute$ TrigAttach | TriggerZones$ Battlefield | TriggerDescription$ Whenever equipped creature leaves the battlefield, you may attach CARDNAME to a creature you control that shares a color with that creature.
+SVar:TrigAttach:DB$ Attach | ValidTgts$ Creature.YouCtrl+SharesColorWith TriggeredCard | TgtPrompt$ Select a creature you control that shares a color with that creature
+K:Equip:2
+Oracle:Equipped creature gets +2/+0.\nWhenever equipped creature leaves the battlefield, you may attach Pounamu Keepsake to a creature you control that shares a color with that creature.\nEquip {2}

--- a/forge-gui/res/cardsfolder/RAK/skyriders_vessel.txt
+++ b/forge-gui/res/cardsfolder/RAK/skyriders_vessel.txt
@@ -1,0 +1,9 @@
+Name:Skyrider's Vessel
+ManaCost:3
+Types:Artifact Vehicle
+PT:5/5
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | TriggerZones$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters the battlefield, create a 1/1 blue Bird creature token with flying.
+T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Opponent | CombatDamage$ True | Execute$ TrigToken | TriggerDescription$ Whenever CARDNAME deals combat damage to an opponent, create a 1/1 blue Bird creature token with flying.
+SVar:TrigToken:DB$ Token | TokenAmount$ 1 | TokenScript$ u_1_1_bird_flying | TokenOwner$ You
+K:Crew:3
+Oracle:Whenever Skyrider's Vessel enters the battlefield or deals combat damage to an opponent, create a 1/1 blue Bird creature token with flying.\nCrew 3 (Tap any number of creatures you control with total power 3 or greater: This Vehicle becomes an artifact creature until end of turn.)

--- a/forge-gui/res/cardsfolder/RAK/the_paradise_gem.txt
+++ b/forge-gui/res/cardsfolder/RAK/the_paradise_gem.txt
@@ -1,0 +1,8 @@
+Name:The Paradise Gem
+ManaCost:4
+Types:Legendary Artifact
+S:Mode$ Continuous | Affected$ Land.YouCtrl | AddType$ AllBasicLandType | Description$ Lands you control are every basic land type in addition to their other types.
+SVar:NonStackingEffect:True
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Land.YouCtrl | Execute$ TrigLife | TriggerDescription$ Whenever a land enters the battlefield under your control, you gain 3 life.
+SVar:TrigLife:DB$ GainLife | LifeAmount$ 3 | Defined$ You
+Oracle:Lands you control are every basic land type in addition to their other types.\nWhenever a land enters the battlefield under your control, you gain 3 life.

--- a/forge-gui/res/cardsfolder/RAK/the_paradise_gem.txt
+++ b/forge-gui/res/cardsfolder/RAK/the_paradise_gem.txt
@@ -3,6 +3,6 @@ ManaCost:4
 Types:Legendary Artifact
 S:Mode$ Continuous | Affected$ Land.YouCtrl | AddType$ AllBasicLandType | Description$ Lands you control are every basic land type in addition to their other types.
 SVar:NonStackingEffect:True
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Land.YouCtrl | Execute$ TrigLife | TriggerDescription$ Whenever a land enters the battlefield under your control, you gain 3 life.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Land.YouCtrl | Execute$ TrigLife | TriggerZones$ Battlefield | TriggerDescription$ Whenever a land enters the battlefield under your control, you gain 3 life.
 SVar:TrigLife:DB$ GainLife | LifeAmount$ 3 | Defined$ You
 Oracle:Lands you control are every basic land type in addition to their other types.\nWhenever a land enters the battlefield under your control, you gain 3 life.

--- a/forge-gui/res/cardsfolder/RAK/third_tooth_tracker.txt
+++ b/forge-gui/res/cardsfolder/RAK/third_tooth_tracker.txt
@@ -1,0 +1,8 @@
+Name:Third-Tooth Tracker
+ManaCost:UB UB UB UB
+Types:Creature Merfolk Scout
+PT:3/3
+T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | CheckSVar$ X | Execute$ TrigDraw | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of your end step, if an opponent lost life this turn, you draw a card.
+SVar:TrigDraw:DB$ Draw | NumCards$ 1 | Defined$ You
+SVar:X:Count$LifeOppsLostThisTurn
+Oracle:At the beginning of your end step, if an opponent lost life this turn, you draw a card.

--- a/forge-gui/res/cardsfolder/RAK/toahangas_charger.txt
+++ b/forge-gui/res/cardsfolder/RAK/toahangas_charger.txt
@@ -3,7 +3,7 @@ ManaCost:RG RG RG RG
 Types:Creature Boar
 PT:4/4
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigPT | OptionalDecider$ You | TriggerDescription$ Whenever CARDNAME attacks, you may choose another target attacking creature. That creature has base power and toughness equal to CARDNAME's power and toughness until end of turn.
-SVar:TrigPT:DB$ Animate | ValidTgts$ Creature.Attacking+Other | TgtPrompt$ Select another target attacking creature | Power$ X | Toughness$ Y | SpellDescription$ That creature has base power and toughness equal to CARDNAME's power and toughness until end of turn.
+SVar:TrigPT:DB$ Animate | ValidTgts$ Creature.Other+attacking | TgtPrompt$ Select another target attacking creature | Power$ X | Toughness$ Y | SpellDescription$ That creature has base power and toughness equal to CARDNAME's power and toughness until end of turn.
 SVar:X:Count$CardPower
 SVar:Y:Count$CardToughness
 Oracle:Whenever Toahanga's Charger attacks, you may choose another target attacking creature. That creature has base power and toughness equal to Toahanga's Charger's power and toughness until end of turn.

--- a/forge-gui/res/cardsfolder/RAK/toahangas_charger.txt
+++ b/forge-gui/res/cardsfolder/RAK/toahangas_charger.txt
@@ -1,0 +1,9 @@
+Name:Toahanga's Charger
+ManaCost:RG RG RG RG
+Types:Creature Boar
+PT:4/4
+T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigPT | OptionalDecider$ You | TriggerDescription$ Whenever CARDNAME attacks, you may choose another target attacking creature. That creature has base power and toughness equal to CARDNAME's power and toughness until end of turn.
+SVar:TrigPT:DB$ Animate | ValidTgts$ Creature.Attacking+Other | TgtPrompt$ Select another target attacking creature | Power$ X | Toughness$ Y | SpellDescription$ That creature has base power and toughness equal to CARDNAME's power and toughness until end of turn.
+SVar:X:Count$CardPower
+SVar:Y:Count$CardToughness
+Oracle:Whenever Toahanga's Charger attacks, you may choose another target attacking creature. That creature has base power and toughness equal to Toahanga's Charger's power and toughness until end of turn.

--- a/forge-gui/res/cardsfolder/RAK/voyagers_vault.txt
+++ b/forge-gui/res/cardsfolder/RAK/voyagers_vault.txt
@@ -1,0 +1,8 @@
+Name:Voyager's Vault
+ManaCost:1
+Types:Artifact Creature Wall
+PT:0/3
+K:Defender
+A:AB$ Mana | Cost$ 2 T Sac<1/CARDNAME> | Produced$ Combo AnyDifferent | Amount$ 2 | SubAbility$ DBDraw | SpellDescription$ Add two mana of different colors. Draw a card.
+SVar:DBDraw:DB$ Draw | NumCards$ 1
+Oracle:Defender\n{2}, {T}, Sacrifice Voyager's Vault: Add two mana of different colors. Draw a card.


### PR DESCRIPTION
## Summary
- add Third-Tooth Tracker with end step card draw trigger
- add Toahanga's Charger to resize another attacking creature
- script voyage artifacts and vehicles for RAK, including Engraved Moai, Pearlescent Egg, and more

## Testing
- `mvn -q test` *(fails: Unresolveable build extension org.apache.maven.wagon:wagon-ftp:3.5.3)*

------
https://chatgpt.com/codex/tasks/task_e_688add9780f083209ac0395bf0e600bc