### PR TITLE
Add RAK land cards

### DIFF
--- a/forge-gui/res/cardsfolder/RAK/coral_barrens.txt
+++ b/forge-gui/res/cardsfolder/RAK/coral_barrens.txt
@@ -1,0 +1,6 @@
+Name:Coral Barrens
+ManaCost:no cost
+Types:Land
+A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
+A:AB$ Destroy | Cost$ 1 T Sac<1/CARDNAME> | ValidTgts$ Land.NonBasic | TgtPrompt$ Select target nonbasic land | IsPresent$ Land.Basic+YouCtrl | PresentCompare$ GE3 | SpellDescription$ Destroy target nonbasic land. Activate only if you control three or more basic lands.
+Oracle:{T}: Add {C}.\\n{1}, {T}, Sacrifice Coral Barrens: Destroy target nonbasic land. Activate only if you control three or more basic lands.

--- a/forge-gui/res/cardsfolder/RAK/crafting_hut.txt
+++ b/forge-gui/res/cardsfolder/RAK/crafting_hut.txt
@@ -1,0 +1,6 @@
+Name:Crafting Hut
+ManaCost:no cost
+Types:Land
+A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
+A:AB$ ChangeZone | Cost$ 2 T Sac<1/CARDNAME> | Origin$ Graveyard | Destination$ Hand | ValidTgts$ Aura.YouOwn | TgtPrompt$ Select target Aura card in your graveyard | SpellDescription$ Return target Aura card from your graveyard to your hand.
+Oracle:{T}: Add {C}.\\n{2}, {T}, Sacrifice Crafting Hut: Return target Aura card from your graveyard to your hand.

--- a/forge-gui/res/cardsfolder/RAK/crossroads_of_paradise.txt
+++ b/forge-gui/res/cardsfolder/RAK/crossroads_of_paradise.txt
@@ -1,0 +1,8 @@
+Name:Crossroads of Paradise
+ManaCost:no cost
+Types:Land
+R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ CARDNAME enters tapped.
+SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
+A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
+A:AB$ ChangeZone | Cost$ 3 T Sac<1/CARDNAME> | Origin$ Library | Destination$ Battlefield | Tapped$ True | ChangeType$ Land.Basic | ChangeNum$ 2 | SpellDescription$ Search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle.
+Oracle:Crossroads of Paradise enters tapped.\\n{T}: Add {C}.\\n{3}, {T}, Sacrifice Crossroads of Paradise: Search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle.

--- a/forge-gui/res/cardsfolder/RAK/elipo_ono_craftland.txt
+++ b/forge-gui/res/cardsfolder/RAK/elipo_ono_craftland.txt
@@ -1,0 +1,9 @@
+Name:Elipo Ono Craftland
+ManaCost:no cost
+Types:Land Plains
+R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ CARDNAME enters tapped.
+SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | IsPresent$ Plains.YouCtrl | PresentCompare$ GE3 | Execute$ TrigPump | TriggerDescription$ Homeland — When CARDNAME enters the battlefield, if you control three or more Plains, target creature you control gets +2/+2 until end of turn.
+SVar:TrigPump:DB$ Pump | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | Power$ 2 | Toughness$ 2 | SpellDescription$ Target creature you control gets +2/+2 until end of turn.
+DeckNeeds:Color$White
+Oracle:({T}: Add {W}.)\\nElipo Ono Craftland enters tapped.\\nHomeland — When Elipo Ono Craftland enters the battlefield, if you control three or more Plains, target creature you control gets +2/+2 until end of turn.

--- a/forge-gui/res/cardsfolder/RAK/flourishing_village.txt
+++ b/forge-gui/res/cardsfolder/RAK/flourishing_village.txt
@@ -1,0 +1,6 @@
+Name:Flourishing Village
+ManaCost:no cost
+Types:Land Forest Plains
+R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplaceWith$ LandTapped | ReplacementResult$ Updated | Description$ CARDNAME enters tapped unless you control three or more other lands.
+SVar:LandTapped:DB$ Tap | Defined$ Self | ETB$ True | ConditionPresent$ Land.YouCtrl+Other | ConditionCompare$ LT3
+Oracle:({T}: Add {G} or {W}.)\\nFlourishing Village enters tapped unless you control three or more other lands.

--- a/forge-gui/res/cardsfolder/RAK/hazed_spire.txt
+++ b/forge-gui/res/cardsfolder/RAK/hazed_spire.txt
@@ -1,0 +1,6 @@
+Name:Hazed Spire
+ManaCost:no cost
+Types:Land Swamp Mountain
+R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplaceWith$ LandTapped | ReplacementResult$ Updated | Description$ CARDNAME enters tapped unless you control three or more other lands.
+SVar:LandTapped:DB$ Tap | Defined$ Self | ETB$ True | ConditionPresent$ Land.YouCtrl+Other | ConditionCompare$ LT3
+Oracle:({T}: Add {B} or {R}.)\\nHazed Spire enters tapped unless you control three or more other lands.

--- a/forge-gui/res/cardsfolder/RAK/mohele_beacon.txt
+++ b/forge-gui/res/cardsfolder/RAK/mohele_beacon.txt
@@ -1,0 +1,9 @@
+Name:Mohele Beacon
+ManaCost:no cost
+Types:Land Island
+R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ CARDNAME enters tapped.
+SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | IsPresent$ Island.YouCtrl | PresentCompare$ GE3 | Execute$ TrigScry | OptionalDecider$ You | TriggerDescription$ Homeland — When CARDNAME enters the battlefield, if you control three or more Islands, you may scry 2.
+SVar:TrigScry:DB$ Scry | ScryNum$ 2 | SpellDescription$ Scry 2.
+DeckNeeds:Color$Blue
+Oracle:({T}: Add {U}.)\\nMohele Beacon enters tapped.\\nHomeland — When Mohele Beacon enters the battlefield, if you control three or more Islands, you may scry 2.

--- a/forge-gui/res/cardsfolder/RAK/mushroom_bog.txt
+++ b/forge-gui/res/cardsfolder/RAK/mushroom_bog.txt
@@ -1,0 +1,6 @@
+Name:Mushroom Bog
+ManaCost:no cost
+Types:Land Swamp Forest
+R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplaceWith$ LandTapped | ReplacementResult$ Updated | Description$ CARDNAME enters tapped unless you control three or more other lands.
+SVar:LandTapped:DB$ Tap | Defined$ Self | ETB$ True | ConditionPresent$ Land.YouCtrl+Other | ConditionCompare$ LT3
+Oracle:({T}: Add {B} or {G}.)\\nMushroom Bog enters tapped unless you control three or more other lands.

--- a/forge-gui/res/cardsfolder/RAK/opaku_monument.txt
+++ b/forge-gui/res/cardsfolder/RAK/opaku_monument.txt
@@ -1,0 +1,9 @@
+Name:Opaku Monument
+ManaCost:no cost
+Types:Land Forest
+R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ CARDNAME enters tapped.
+SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | IsPresent$ Forest.YouCtrl | PresentCompare$ GE3 | Execute$ TrigCounter | TriggerDescription$ Homeland — When CARDNAME enters the battlefield, if you control three or more Forests, put a +1/+1 counter on target creature you control.
+SVar:TrigCounter:DB$ PutCounter | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | CounterType$ P1P1 | CounterNum$ 1 | SpellDescription$ Put a +1/+1 counter on target creature you control.
+DeckNeeds:Color$Green
+Oracle:({T}: Add {G}.)\\nOpaku Monument enters tapped.\\nHomeland — When Opaku Monument enters the battlefield, if you control three or more Forests, put a +1/+1 counter on target creature you control.

--- a/forge-gui/res/cardsfolder/RAK/peaceful_lagoon.txt
+++ b/forge-gui/res/cardsfolder/RAK/peaceful_lagoon.txt
@@ -1,0 +1,6 @@
+Name:Peaceful Lagoon
+ManaCost:no cost
+Types:Land Plains Island
+R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplaceWith$ LandTapped | ReplacementResult$ Updated | Description$ CARDNAME enters tapped unless you control three or more other lands.
+SVar:LandTapped:DB$ Tap | Defined$ Self | ETB$ True | ConditionPresent$ Land.YouCtrl+Other | ConditionCompare$ LT3
+Oracle:({T}: Add {W} or {U}.)\\nPeaceful Lagoon enters tapped unless you control three or more other lands.

--- a/forge-gui/res/cardsfolder/RAK/robust_tangle.txt
+++ b/forge-gui/res/cardsfolder/RAK/robust_tangle.txt
@@ -1,0 +1,6 @@
+Name:Robust Tangle
+ManaCost:no cost
+Types:Land Mountain Forest
+R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplaceWith$ LandTapped | ReplacementResult$ Updated | Description$ CARDNAME enters tapped unless you control three or more other lands.
+SVar:LandTapped:DB$ Tap | Defined$ Self | ETB$ True | ConditionPresent$ Land.YouCtrl+Other | ConditionCompare$ LT3
+Oracle:({T}: Add {R} or {G}.)\\nRobust Tangle enters tapped unless you control three or more other lands.

--- a/forge-gui/res/cardsfolder/RAK/ru_kano_ruins.txt
+++ b/forge-gui/res/cardsfolder/RAK/ru_kano_ruins.txt
@@ -1,0 +1,10 @@
+Name:Ru Kano Ruins
+ManaCost:no cost
+Types:Land Swamp
+R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ CARDNAME enters tapped.
+SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | IsPresent$ Swamp.YouCtrl | PresentCompare$ GE3 | Execute$ TrigLose | TriggerDescription$ Homeland — When CARDNAME enters the battlefield, if you control three or more Swamps, each opponent loses 1 life and you gain 1 life.
+SVar:TrigLose:DB$ LoseLife | Defined$ Opponent | LifeAmount$ 1 | SubAbility$ DBGain | SpellDescription$ Each opponent loses 1 life and you gain 1 life.
+SVar:DBGain:DB$ GainLife | Defined$ You | LifeAmount$ 1
+DeckNeeds:Color$Black
+Oracle:({T}: Add {B}.)\\nRu Kano Ruins enters tapped.\\nHomeland — When Ru Kano Ruins enters the battlefield, if you control three or more Swamps, each opponent loses 1 life and you gain 1 life.

--- a/forge-gui/res/cardsfolder/RAK/sea-soaked_cliff.txt
+++ b/forge-gui/res/cardsfolder/RAK/sea-soaked_cliff.txt
@@ -1,0 +1,6 @@
+Name:Sea-Soaked Cliff
+ManaCost:no cost
+Types:Land Island Mountain
+R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplaceWith$ LandTapped | ReplacementResult$ Updated | Description$ CARDNAME enters tapped unless you control three or more other lands.
+SVar:LandTapped:DB$ Tap | Defined$ Self | ETB$ True | ConditionPresent$ Land.YouCtrl+Other | ConditionCompare$ LT3
+Oracle:({T}: Add {U} or {R}.)\\nSea-Soaked Cliff enters tapped unless you control three or more other lands.

--- a/forge-gui/res/cardsfolder/RAK/seaside_cavern.txt
+++ b/forge-gui/res/cardsfolder/RAK/seaside_cavern.txt
@@ -1,0 +1,6 @@
+Name:Seaside Cavern
+ManaCost:no cost
+Types:Land Island Swamp
+R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplaceWith$ LandTapped | ReplacementResult$ Updated | Description$ CARDNAME enters tapped unless you control three or more other lands.
+SVar:LandTapped:DB$ Tap | Defined$ Self | ETB$ True | ConditionPresent$ Land.YouCtrl+Other | ConditionCompare$ LT3
+Oracle:({T}: Add {U} or {B}.)\\nSeaside Cavern enters tapped unless you control three or more other lands.

--- a/forge-gui/res/cardsfolder/RAK/shaded_shelter.txt
+++ b/forge-gui/res/cardsfolder/RAK/shaded_shelter.txt
@@ -1,0 +1,6 @@
+Name:Shaded Shelter
+ManaCost:no cost
+Types:Land Plains Swamp
+R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplaceWith$ LandTapped | ReplacementResult$ Updated | Description$ CARDNAME enters tapped unless you control three or more other lands.
+SVar:LandTapped:DB$ Tap | Defined$ Self | ETB$ True | ConditionPresent$ Land.YouCtrl+Other | ConditionCompare$ LT3
+Oracle:({T}: Add {W} or {B}.)\\nShaded Shelter enters tapped unless you control three or more other lands.

--- a/forge-gui/res/cardsfolder/RAK/shellback_tradepost.txt
+++ b/forge-gui/res/cardsfolder/RAK/shellback_tradepost.txt
@@ -1,0 +1,9 @@
+Name:Shellback Tradepost
+ManaCost:no cost
+Types:Land
+R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ CARDNAME enters tapped.
+SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigStay | TriggerDescription$ When CARDNAME enters the battlefield, it doesn't untap during its controller's next untap step.
+SVar:TrigStay:DB$ Pump | Defined$ Self | KW$ HIDDEN This card doesn't untap during your next untap step. | Duration$ Permanent
+A:AB$ Mana | Cost$ T | Produced$ Any | Amount$ 1 | SpellDescription$ Add one mana of any color.
+Oracle:Shellback Tradepost enters tapped.\\nWhen Shellback Tradepost enters the battlefield, it doesn't untap during its controller's next untap step.\\n{T}: Add one mana of any color.

--- a/forge-gui/res/cardsfolder/RAK/tropical_channel.txt
+++ b/forge-gui/res/cardsfolder/RAK/tropical_channel.txt
@@ -1,0 +1,6 @@
+Name:Tropical Channel
+ManaCost:no cost
+Types:Land Forest Island
+R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplaceWith$ LandTapped | ReplacementResult$ Updated | Description$ CARDNAME enters tapped unless you control three or more other lands.
+SVar:LandTapped:DB$ Tap | Defined$ Self | ETB$ True | ConditionPresent$ Land.YouCtrl+Other | ConditionCompare$ LT3
+Oracle:({T}: Add {G} or {U}.)\\nTropical Channel enters tapped unless you control three or more other lands.

--- a/forge-gui/res/cardsfolder/RAK/utamu_tubes.txt
+++ b/forge-gui/res/cardsfolder/RAK/utamu_tubes.txt
@@ -1,0 +1,9 @@
+Name:Utamu Tubes
+ManaCost:no cost
+Types:Land Mountain
+R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ CARDNAME enters tapped.
+SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | IsPresent$ Mountain.YouCtrl | PresentCompare$ GE3 | Execute$ TrigToken | TriggerDescription$ Homeland — When CARDNAME enters the battlefield, if you control three or more Mountains, create a 1/1 red Elemental creature token.
+SVar:TrigToken:DB$ Token | TokenAmount$ 1 | TokenScript$ r_1_1_elemental | TokenOwner$ You | SpellDescription$ Create a 1/1 red Elemental creature token.
+DeckNeeds:Color$Red
+Oracle:({T}: Add {R}.)\\nUtamu Tubes enters tapped.\\nHomeland — When Utamu Tubes enters the battlefield, if you control three or more Mountains, create a 1/1 red Elemental creature token.

--- a/forge-gui/res/cardsfolder/RAK/valley_shrine.txt
+++ b/forge-gui/res/cardsfolder/RAK/valley_shrine.txt
@@ -1,0 +1,6 @@
+Name:Valley Shrine
+ManaCost:no cost
+Types:Land
+A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
+S:Mode$ ReduceCost | ValidCard$ Card | ValidTarget$ Card.Self | Activator$ You | Type$ Spell | Amount$ 1 | Description$ Spells you cast that target CARDNAME cost {1} less to cast.
+Oracle:{T}: Add {C}.\\nSpells you cast that target Valley Shrine cost {1} less to cast.

--- a/forge-gui/res/cardsfolder/RAK/world_seed.txt
+++ b/forge-gui/res/cardsfolder/RAK/world_seed.txt
@@ -1,0 +1,8 @@
+Name:World Seed
+ManaCost:no cost
+Types:Land
+R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ CARDNAME enters tapped.
+SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
+A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
+A:AB$ Animate | Cost$ 10 | Defined$ Self | Power$ 10 | Toughness$ 10 | Types$ Creature,Elemental | Keywords$ Flying & Vigilance & Trample & Menace & Lifelink | SpellDescription$ CARDNAME becomes a 10/10 Elemental creature with flying, vigilance, trample, menace, and lifelink until end of turn.
+Oracle:Flying, vigilance, trample, menace, lifelink\\nWorld Seed enters tapped.\\n{T}: Add {C}.\\n{10}: World Seed becomes a 10/10 Elemental creature with flying, vigilance, trample, menace, and lifelink until end of turn.

--- a/forge-gui/res/cardsfolder/RAK/zephyr_peak.txt
+++ b/forge-gui/res/cardsfolder/RAK/zephyr_peak.txt
@@ -1,0 +1,6 @@
+Name:Zephyr Peak
+ManaCost:no cost
+Types:Land Mountain Plains
+R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplaceWith$ LandTapped | ReplacementResult$ Updated | Description$ CARDNAME enters tapped unless you control three or more other lands.
+SVar:LandTapped:DB$ Tap | Defined$ Self | ETB$ True | ConditionPresent$ Land.YouCtrl+Other | ConditionCompare$ LT3
+Oracle:({T}: Add {R} or {W}.)\\nZephyr Peak enters tapped unless you control three or more other lands.


### PR DESCRIPTION
## Summary
- script diverse RAK lands including fetch, Homeland, and animation abilities

## Testing
- `mvn -q test` *(fails: Unresolveable build extension org.apache.maven.wagon:wagon-ftp:3.5.3)*

------
https://chatgpt.com/codex/tasks/task_e_688ae533fedc83209977daa81b1ab7a4