### PR TITLE
Add HZN custom card scripts

### DIFF
--- a/forge-gui/res/cardsfolder/HZN/demonbane_grenadier.txt
+++ b/forge-gui/res/cardsfolder/HZN/demonbane_grenadier.txt
@@ -1,0 +1,10 @@
+Name:Demonbane Grenadier
+ManaCost:W W
+Types:Creature Human Cleric Soldier
+PT:2/2
+T:Mode$ SearchedLibrary | ValidPlayer$ Player | SearchOwnLibrary$ True | Execute$ TrigEffect | TriggerZones$ Battlefield | TriggerDescription$ Whenever a player searches their library, that player can't untap more than two permanents during their next untap step.
+SVar:TrigEffect:DB$ Effect | StaticAbilities$ STNoUntap | Triggers$ RemoveEffect | Duration$ Permanent | RememberObjects$ TriggeredPlayer | SpellDescription$ That player can't untap more than two permanents during their next untap step.
+SVar:STNoUntap:Mode$ Continuous | Affected$ Player.Remembered | AddKeyword$ UntapAdjust:Permanent:2 | Description$ Player can't untap more than two permanents during their next untap step.
+SVar:RemoveEffect:T:Mode$ Untap | ValidPlayer$ Remembered | IsPresent$ Player.Active | ValidStep$ Untap | TriggerZones$ Command | Execute$ TrigCleanup | TriggerDescription$ At the beginning of that player's next untap step, remove this effect.
+SVar:TrigCleanup:DB$ Cleanup | ClearRemembered$ True
+Oracle:Whenever a player searches their library, that player can't untap more than two permanents during their next untap step.

--- a/forge-gui/res/cardsfolder/HZN/demonbane_grenadier.txt
+++ b/forge-gui/res/cardsfolder/HZN/demonbane_grenadier.txt
@@ -3,8 +3,6 @@ ManaCost:W W
 Types:Creature Human Cleric Soldier
 PT:2/2
 T:Mode$ SearchedLibrary | ValidPlayer$ Player | SearchOwnLibrary$ True | Execute$ TrigEffect | TriggerZones$ Battlefield | TriggerDescription$ Whenever a player searches their library, that player can't untap more than two permanents during their next untap step.
-SVar:TrigEffect:DB$ Effect | StaticAbilities$ STNoUntap | Triggers$ RemoveEffect | Duration$ Permanent | RememberObjects$ TriggeredPlayer | SpellDescription$ That player can't untap more than two permanents during their next untap step.
-SVar:STNoUntap:Mode$ Continuous | Affected$ Player.Remembered | AddKeyword$ UntapAdjust:Permanent:2 | Description$ Player can't untap more than two permanents during their next untap step.
-SVar:RemoveEffect:T:Mode$ Untap | ValidPlayer$ Remembered | IsPresent$ Player.Active | ValidStep$ Untap | TriggerZones$ Command | Execute$ TrigCleanup | TriggerDescription$ At the beginning of that player's next untap step, remove this effect.
-SVar:TrigCleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:TrigEffect:DB$ Effect | RememberObjects$ TriggeredPlayer | EffectOwner$ TriggeredPlayer | StaticAbilities$ LimitUntap | Duration$ UntilTheEndOfYourNextUntap
+SVar:LimitUntap:Mode$ Continuous | Affected$ Player.IsRemembered | AddKeyword$ UntapAdjust:Permanent:2 | Description$ That player can't untap more than two permanents during their next untap step.
 Oracle:Whenever a player searches their library, that player can't untap more than two permanents during their next untap step.

--- a/forge-gui/res/cardsfolder/HZN/eye_of_dismay.txt
+++ b/forge-gui/res/cardsfolder/HZN/eye_of_dismay.txt
@@ -2,10 +2,9 @@ Name:Eye of Dismay
 ManaCost:1 U U
 Types:Creature Horror
 PT:3/1
-S:Mode$ Continuous | Affected$ Player.Opponent | AddKeyword$ RevealedHand | Description$ Your opponents play with their hands revealed.
-T:Mode$ Phase | Phase$ EndOfTurn | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigName | TriggerDescription$ At the beginning of your end step, choose a card name.
-SVar:TrigName:DB$ NameCard | Defined$ You | RememberChosen$ True
-S:Mode$ CantTarget | ValidPlayer$ You | ValidSource$ Card.NamedCard+OpponentCtrl | Description$ You can't be the target of sources your opponents control with a name chosen by CARDNAME.
-S:Mode$ CantTarget | ValidCard$ Spell.YouCtrl | ValidSource$ Card.NamedCard+OpponentCtrl | Description$ Spells you control can't be the targets of sources your opponents control with a name chosen by CARDNAME.
-S:Mode$ Continuous | Affected$ Card.Self | AddKeyword$ Protection:Card.NamedCard | Description$ CARDNAME has protection from names chosen by it.
-Oracle:Your opponents play with their hands revealed.\nAt the beginning of your end step, choose a card name.\nYou and spells you control can't be targeted by sources your opponents control with a name chosen by Eye of Dismay.\nEye of Dismay has protection from names chosen by it.
+S:Mode$ Continuous | AffectedZone$ Hand | Affected$ Card.OppOwn | MayLookAt$ Player | Description$ Your opponents play with their hands revealed.
+T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigName | TriggerDescription$ At the beginning of your end step, choose a card name.
+SVar:TrigName:DB$ NameCard | Defined$ You
+S:Mode$ CantTarget | Affected$ You,Spell.YouCtrl | ValidSource$ Card.OppCtrl+NamedCard | Description$ You and spells you control can't be targeted by sources your opponents control with the chosen name.
+S:Mode$ Continuous | Affected$ Card.Self | AddKeyword$ Protection:ChosenName | Description$ CARDNAME has protection from the chosen name.
+Oracle:Your opponents play with their hands revealed.\nAt the beginning of your end step, choose a card name.\nYou and spells you control can't be targeted by sources your opponents control with a name chosen by CARDNAME.\nCARDNAME has protection from names chosen by it.

--- a/forge-gui/res/cardsfolder/HZN/eye_of_dismay.txt
+++ b/forge-gui/res/cardsfolder/HZN/eye_of_dismay.txt
@@ -1,0 +1,11 @@
+Name:Eye of Dismay
+ManaCost:1 U U
+Types:Creature Horror
+PT:3/1
+S:Mode$ Continuous | Affected$ Player.Opponent | AddKeyword$ RevealedHand | Description$ Your opponents play with their hands revealed.
+T:Mode$ Phase | Phase$ EndOfTurn | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigName | TriggerDescription$ At the beginning of your end step, choose a card name.
+SVar:TrigName:DB$ NameCard | Defined$ You | RememberChosen$ True
+S:Mode$ CantTarget | ValidPlayer$ You | ValidSource$ Card.NamedCard+OpponentCtrl | Description$ You can't be the target of sources your opponents control with a name chosen by CARDNAME.
+S:Mode$ CantTarget | ValidCard$ Spell.YouCtrl | ValidSource$ Card.NamedCard+OpponentCtrl | Description$ Spells you control can't be the targets of sources your opponents control with a name chosen by CARDNAME.
+S:Mode$ Continuous | Affected$ Card.Self | AddKeyword$ Protection:Card.NamedCard | Description$ CARDNAME has protection from names chosen by it.
+Oracle:Your opponents play with their hands revealed.\nAt the beginning of your end step, choose a card name.\nYou and spells you control can't be targeted by sources your opponents control with a name chosen by Eye of Dismay.\nEye of Dismay has protection from names chosen by it.

--- a/forge-gui/res/cardsfolder/HZN/hexplate_companion.txt
+++ b/forge-gui/res/cardsfolder/HZN/hexplate_companion.txt
@@ -1,0 +1,8 @@
+Name:Hexplate Companion
+ManaCost:1 W
+Types:Artifact Creature Golem
+PT:2/1
+K:ETBReplacement:Other:DBNameCard
+SVar:DBNameCard:DB$ NameCard | Defined$ You | SpellDescription$ As CARDNAME enters, choose a card name.
+S:Mode$ Continuous | Affected$ You,Card.Self | AddKeyword$ Protection:ChosenName | Description$ You and CARDNAME each have protection from the chosen card name.
+Oracle:As Hexplate Companion enters, choose a card name.\nYou and Hexplate Companion each have protection from the chosen card name.

--- a/forge-gui/res/cardsfolder/HZN/invent_the_future.txt
+++ b/forge-gui/res/cardsfolder/HZN/invent_the_future.txt
@@ -1,7 +1,7 @@
 Name:Invent the Future
 ManaCost:X U U U
 Types:Instant
-A:SP$ Draw | NumCards$ X | Defined$ You | SpellDescription$ Draw X cards.
-SVar:X:Count$xPaid
 K:Flashback:U U U Sac<X/Permanent>
+A:SP$ Draw | NumCards$ X | SpellDescription$ Draw X cards.
+SVar:X:Count$xPaid
 Oracle:Draw X cards.\nFlashback—{U}{U}{U}, Sacrifice X permanents. (You may cast this card from your graveyard for its flashback cost. Then exile it.)

--- a/forge-gui/res/cardsfolder/HZN/invent_the_future.txt
+++ b/forge-gui/res/cardsfolder/HZN/invent_the_future.txt
@@ -1,0 +1,7 @@
+Name:Invent the Future
+ManaCost:X U U U
+Types:Instant
+A:SP$ Draw | NumCards$ X | Defined$ You | SpellDescription$ Draw X cards.
+SVar:X:Count$xPaid
+K:Flashback:U U U Sac<X/Permanent>
+Oracle:Draw X cards.\nFlashback—{U}{U}{U}, Sacrifice X permanents. (You may cast this card from your graveyard for its flashback cost. Then exile it.)

--- a/forge-gui/res/cardsfolder/HZN/kenleigh_liege_of_redemption.txt
+++ b/forge-gui/res/cardsfolder/HZN/kenleigh_liege_of_redemption.txt
@@ -3,5 +3,7 @@ ManaCost:1 W W
 Types:Legendary Creature Human Knight
 PT:3/3
 K:Lifelink
-# TODO: Creature and Aura cards with mana value 3 or less in your graveyard have revive {2}{W/B}. ({2}{W/B}, Exile that card from your graveyard: Create a token that's a copy of it except it has no mana cost. Revive only as a sorcery.)
+S:Mode$ Continuous | Affected$ Creature.YouCtrl+cmcLE3,Aura.YouCtrl+cmcLE3 | AffectedZone$ Graveyard | AddAbility$ ABRevive | Description$ Creature and Aura cards with mana value 3 or less in your graveyard have revive {2}{W/B}. ({2}{W/B}, Exile that card from your graveyard: Create a token that's a copy of it except it has no mana cost. Revive only as a sorcery.)
+SVar:ABRevive:AB$ CopyPermanent | ActivationZone$ Graveyard | SorcerySpeed$ True | Cost$ 2 WB ExileFromGrave<1/CARDNAME> | Defined$ Self | RemoveCost$ True | PrecostDesc$ Revive | CostDesc$ {2}{W/B} | SpellDescription$ ({2}{W/B}, Exile this card from your graveyard: Create a token that's a copy of it except it has no mana cost. Revive only as a sorcery.)
+DeckHints:Type$Aura
 Oracle:Lifelink\nCreature and Aura cards with mana value 3 or less in your graveyard have revive {2}{W/B}. ({2}{W/B}, Exile that card from your graveyard: Create a token that's a copy of it except it has no mana cost. Revive only as a sorcery.)

--- a/forge-gui/res/cardsfolder/HZN/kenleigh_liege_of_redemption.txt
+++ b/forge-gui/res/cardsfolder/HZN/kenleigh_liege_of_redemption.txt
@@ -1,0 +1,7 @@
+Name:Kenleigh, Liege of Redemption
+ManaCost:1 W W
+Types:Legendary Creature Human Knight
+PT:3/3
+K:Lifelink
+# TODO: Creature and Aura cards with mana value 3 or less in your graveyard have revive {2}{W/B}. ({2}{W/B}, Exile that card from your graveyard: Create a token that's a copy of it except it has no mana cost. Revive only as a sorcery.)
+Oracle:Lifelink\nCreature and Aura cards with mana value 3 or less in your graveyard have revive {2}{W/B}. ({2}{W/B}, Exile that card from your graveyard: Create a token that's a copy of it except it has no mana cost. Revive only as a sorcery.)

--- a/forge-gui/res/cardsfolder/HZN/lay_low.txt
+++ b/forge-gui/res/cardsfolder/HZN/lay_low.txt
@@ -1,6 +1,6 @@
 Name:Lay Low
 ManaCost:W
 Types:Instant
-A:SP$ Counter | TargetType$ Spell | TgtPrompt$ Select target spell | ValidTgts$ Card | TargetValidTargeting$ Permanent.YouCtrl+inRealZoneBattlefield,You | SubAbility$ DBSurveil | SpellDescription$ Counter target spell that targets you or a permanent you control. Surveil 1.
-SVar:DBSurveil:DB$ Surveil | Amount$ 1
+A:SP$ Counter | TargetType$ Spell | TgtPrompt$ Select target spell | ValidTgts$ Card | TargetValidTargeting$ You,Permanent.YouCtrl+inRealZoneBattlefield | SubAbility$ DBSurveil | SpellDescription$ Counter target spell that targets you or a permanent you control. Surveil 1. (Look at the top card of your library. You may put that card into your graveyard.)
+SVar:DBSurveil:DB$ Surveil | Defined$ You | Amount$ 1
 Oracle:Counter target spell that targets you or a permanent you control.\nSurveil 1. (Look at the top card of your library. You may put that card into your graveyard.)

--- a/forge-gui/res/cardsfolder/HZN/lay_low.txt
+++ b/forge-gui/res/cardsfolder/HZN/lay_low.txt
@@ -1,0 +1,6 @@
+Name:Lay Low
+ManaCost:W
+Types:Instant
+A:SP$ Counter | TargetType$ Spell | TgtPrompt$ Select target spell | ValidTgts$ Card | TargetValidTargeting$ Permanent.YouCtrl+inRealZoneBattlefield,You | SubAbility$ DBSurveil | SpellDescription$ Counter target spell that targets you or a permanent you control. Surveil 1.
+SVar:DBSurveil:DB$ Surveil | Amount$ 1
+Oracle:Counter target spell that targets you or a permanent you control.\nSurveil 1. (Look at the top card of your library. You may put that card into your graveyard.)

--- a/forge-gui/res/cardsfolder/HZN/protective_memory.txt
+++ b/forge-gui/res/cardsfolder/HZN/protective_memory.txt
@@ -2,7 +2,8 @@ Name:Protective Memory
 ManaCost:W W
 Types:Creature Reflection Cleric
 PT:1/1
-S:Mode$ Continuous | Affected$ Creature.YouCtrl+Other+Cleric,Creature.YouCtrl+Other+Reflection | AddPower$ 1 | AddToughness$ 1 | Description$ Each other creature you control that's a Cleric or a Reflection gets +1/+1.
-S:Mode$ Continuous | Affected$ Card.Self | AddPower$ 3 | AddToughness$ 3 | CheckSVar$ X | SVarCompare$ GE1 | Description$ CARDNAME gets +3/+3 as long as you've gained life this turn.
-SVar:X:Count$LifeYouGainedThisTurn
-Oracle:Each other creature you control that's a Cleric or a Reflection gets +1/+1.\nProtective Memory gets +3/+3 as long as you've gained life this turn.
+S:Mode$ Continuous | Affected$ Creature.Other+YouCtrl+Cleric,Creature.Other+YouCtrl+Reflection | AddPower$ 1 | AddToughness$ 1 | Description$ Each other creature you control that's a Cleric or a Reflection gets +1/+1.
+S:Mode$ Continuous | Affected$ Card.Self | AddPower$ 3 | AddToughness$ 3 | CheckSVar$ YouLifeGained | SVarCompare$ GE1 | Description$ CARDNAME gets +3/+3 as long as you've gained life this turn.
+SVar:YouLifeGained:Count$LifeYouGainedThisTurn
+DeckHints:Type$Knight|Reflection
+Oracle:Each other Cleric or Reflection creature you control gets +1/+1.\nCARDNAME gets +3/+3 as long as you've gained life this turn.

--- a/forge-gui/res/cardsfolder/HZN/protective_memory.txt
+++ b/forge-gui/res/cardsfolder/HZN/protective_memory.txt
@@ -1,0 +1,8 @@
+Name:Protective Memory
+ManaCost:W W
+Types:Creature Reflection Cleric
+PT:1/1
+S:Mode$ Continuous | Affected$ Creature.YouCtrl+Other+Cleric,Creature.YouCtrl+Other+Reflection | AddPower$ 1 | AddToughness$ 1 | Description$ Each other creature you control that's a Cleric or a Reflection gets +1/+1.
+S:Mode$ Continuous | Affected$ Card.Self | AddPower$ 3 | AddToughness$ 3 | CheckSVar$ X | SVarCompare$ GE1 | Description$ CARDNAME gets +3/+3 as long as you've gained life this turn.
+SVar:X:Count$LifeYouGainedThisTurn
+Oracle:Each other creature you control that's a Cleric or a Reflection gets +1/+1.\nProtective Memory gets +3/+3 as long as you've gained life this turn.

--- a/forge-gui/res/cardsfolder/HZN/souls_attendant.txt
+++ b/forge-gui/res/cardsfolder/HZN/souls_attendant.txt
@@ -1,0 +1,7 @@
+Name:Soul's Attendant
+ManaCost:W
+Types:Creature Human Cleric
+PT:1/1
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Creature.Other | TriggerZones$ Battlefield | OptionalDecider$ You | Execute$ TrigGainLife | TriggerDescription$ Whenever another creature enters, you may gain 1 life.
+SVar:TrigGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 1
+Oracle:Whenever another creature enters, you may gain 1 life.

--- a/forge-gui/res/cardsfolder/HZN/souls_attendant.txt
+++ b/forge-gui/res/cardsfolder/HZN/souls_attendant.txt
@@ -1,7 +1,0 @@
-Name:Soul's Attendant
-ManaCost:W
-Types:Creature Human Cleric
-PT:1/1
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Creature.Other | TriggerZones$ Battlefield | OptionalDecider$ You | Execute$ TrigGainLife | TriggerDescription$ Whenever another creature enters, you may gain 1 life.
-SVar:TrigGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 1
-Oracle:Whenever another creature enters, you may gain 1 life.

--- a/forge-gui/res/cardsfolder/HZN/tyriel_angelic_artisan.txt
+++ b/forge-gui/res/cardsfolder/HZN/tyriel_angelic_artisan.txt
@@ -5,8 +5,10 @@ PT:4/4
 K:Flying
 K:Vigilance
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigSearch | OptionalDecider$ You | TriggerDescription$ When CARDNAME enters, you may search your library for an Equipment card, reveal it, put it into your hand, then shuffle.
-SVar:TrigSearch:DB$ ChangeZone | Origin$ Library | Destination$ Hand | ChangeType$ Equipment | ChangeNum$ 1 | Reveal$ True | Shuffle$ True | SpellDescription$ Search your library for an Equipment card, reveal it, put it into your hand, then shuffle.
-T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigPut | OptionalDecider$ You | TriggerDescription$ Whenever CARDNAME attacks, you may put an Equipment card from your hand onto the battlefield, then attach it to CARDNAME.
-SVar:TrigPut:DB$ ChangeZone | Origin$ Hand | Destination$ Battlefield | ValidTgts$ Equipment.YouCtrl | TgtPrompt$ Select an Equipment card in your hand | SubAbility$ DBAttach | SpellDescription$ Put an Equipment card from your hand onto the battlefield, then attach it to CARDNAME.
-SVar:DBAttach:DB$ Attach | Object$ Targeted | Defined$ Self
+SVar:TrigSearch:DB$ ChangeZone | Origin$ Library | Destination$ Hand | ChangeType$ Card.Equipment | ChangeNum$ 1 | Reveal$ True | ShuffleNonMandatory$ True
+T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigEquip | OptionalDecider$ You | TriggerDescription$ Whenever CARDNAME attacks, you may put an Equipment card from your hand onto the battlefield, then attach it to CARDNAME.
+SVar:TrigEquip:DB$ ChangeZone | Origin$ Hand | Destination$ Battlefield | ChangeType$ Equipment | ChangeNum$ 1 | RememberChanged$ True | SubAbility$ DBAttach
+SVar:DBAttach:DB$ Attach | Object$ Remembered | Defined$ Self | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+DeckHints:Type$Equipment
 Oracle:Flying, vigilance\nWhen Tyriel, Angelic Artisan enters, you may search your library for an Equipment card, reveal it, put it into your hand, then shuffle.\nWhenever Tyriel attacks, you may put an Equipment card from your hand onto the battlefield, then attach it to Tyriel.

--- a/forge-gui/res/cardsfolder/HZN/tyriel_angelic_artisan.txt
+++ b/forge-gui/res/cardsfolder/HZN/tyriel_angelic_artisan.txt
@@ -1,0 +1,12 @@
+Name:Tyriel, Angelic Artisan
+ManaCost:3 W W
+Types:Legendary Creature Angel Artificer
+PT:4/4
+K:Flying
+K:Vigilance
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigSearch | OptionalDecider$ You | TriggerDescription$ When CARDNAME enters, you may search your library for an Equipment card, reveal it, put it into your hand, then shuffle.
+SVar:TrigSearch:DB$ ChangeZone | Origin$ Library | Destination$ Hand | ChangeType$ Equipment | ChangeNum$ 1 | Reveal$ True | Shuffle$ True | SpellDescription$ Search your library for an Equipment card, reveal it, put it into your hand, then shuffle.
+T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigPut | OptionalDecider$ You | TriggerDescription$ Whenever CARDNAME attacks, you may put an Equipment card from your hand onto the battlefield, then attach it to CARDNAME.
+SVar:TrigPut:DB$ ChangeZone | Origin$ Hand | Destination$ Battlefield | ValidTgts$ Equipment.YouCtrl | TgtPrompt$ Select an Equipment card in your hand | SubAbility$ DBAttach | SpellDescription$ Put an Equipment card from your hand onto the battlefield, then attach it to CARDNAME.
+SVar:DBAttach:DB$ Attach | Object$ Targeted | Defined$ Self
+Oracle:Flying, vigilance\nWhen Tyriel, Angelic Artisan enters, you may search your library for an Equipment card, reveal it, put it into your hand, then shuffle.\nWhenever Tyriel attacks, you may put an Equipment card from your hand onto the battlefield, then attach it to Tyriel.

--- a/forge-gui/res/cardsfolder/HZN/waxing_angel.txt
+++ b/forge-gui/res/cardsfolder/HZN/waxing_angel.txt
@@ -4,9 +4,9 @@ Types:Creature Angel
 PT:1/1
 K:Flying
 K:Lifelink
-T:Mode$ Phase | Phase$ EndOfTurn | ValidPlayer$ Each | TriggerZones$ Battlefield | CheckSVar$ X | SVarCompare$ GE3 | Execute$ TrigChoose | TriggerDescription$ At the beginning of each end step, if you gained 3 or more life this turn, choose one —\n• Put a +1/+1 counter on CARDNAME.\n• Exile target artifact or enchantment.
-SVar:X:Count$LifeYouGainedThisTurn
-SVar:TrigChoose:DB$ ChooseMode | Choices$ DBPutCounter,DBExile | SpellDescription$ Choose one — Put a +1/+1 counter on CARDNAME; or exile target artifact or enchantment.
-SVar:DBPutCounter:DB$ PutCounter | Defined$ Self | CounterType$ P1P1 | CounterNum$ 1 | SpellDescription$ Put a +1/+1 counter on CARDNAME.
-SVar:DBExile:DB$ ChangeZone | ValidTgts$ Artifact,Enchantment | Origin$ Battlefield | Destination$ Exile | TgtPrompt$ Select target artifact or enchantment | SpellDescription$ Exile target artifact or enchantment.
-Oracle:Flying, lifelink\nAt the beginning of each end step, if you gained 3 or more life this turn, choose one —\n• Put a +1/+1 counter on Waxing Angel.\n• Exile target artifact or enchantment.
+T:Mode$ Phase | Phase$ End of Turn | TriggerZones$ Battlefield | CheckSVar$ YouLifeGained | SVarCompare$ GE3 | Execute$ TrigChoice | TriggerDescription$ At the beginning of each end step, if you gained 3 or more life this turn, choose one —\n• Put a +1/+1 counter on CARDNAME.\n• Exile target artifact or enchantment.
+SVar:TrigChoice:DB$ Charm | Choices$ PutCounter,ExileAE | CharmNum$ 1
+SVar:PutCounter:DB$ PutCounter | Defined$ Self | CounterType$ P1P1 | CounterNum$ 1 | SpellDescription$ Put a +1/+1 counter on CARDNAME.
+SVar:ExileAE:DB$ ChangeZone | Origin$ Battlefield | Destination$ Exile | ValidTgts$ Artifact,Enchantment | TgtPrompt$ Select target artifact or enchantment | SpellDescription$ Exile target artifact or enchantment.
+SVar:YouLifeGained:Count$LifeYouGainedThisTurn
+Oracle:Flying, lifelink\nAt the beginning of each end step, if you gained 3 or more life this turn, choose one —\n• Put a +1/+1 counter on CARDNAME.\n• Exile target artifact or enchantment.

--- a/forge-gui/res/cardsfolder/HZN/waxing_angel.txt
+++ b/forge-gui/res/cardsfolder/HZN/waxing_angel.txt
@@ -1,0 +1,12 @@
+Name:Waxing Angel
+ManaCost:W
+Types:Creature Angel
+PT:1/1
+K:Flying
+K:Lifelink
+T:Mode$ Phase | Phase$ EndOfTurn | ValidPlayer$ Each | TriggerZones$ Battlefield | CheckSVar$ X | SVarCompare$ GE3 | Execute$ TrigChoose | TriggerDescription$ At the beginning of each end step, if you gained 3 or more life this turn, choose one —\n• Put a +1/+1 counter on CARDNAME.\n• Exile target artifact or enchantment.
+SVar:X:Count$LifeYouGainedThisTurn
+SVar:TrigChoose:DB$ ChooseMode | Choices$ DBPutCounter,DBExile | SpellDescription$ Choose one — Put a +1/+1 counter on CARDNAME; or exile target artifact or enchantment.
+SVar:DBPutCounter:DB$ PutCounter | Defined$ Self | CounterType$ P1P1 | CounterNum$ 1 | SpellDescription$ Put a +1/+1 counter on CARDNAME.
+SVar:DBExile:DB$ ChangeZone | ValidTgts$ Artifact,Enchantment | Origin$ Battlefield | Destination$ Exile | TgtPrompt$ Select target artifact or enchantment | SpellDescription$ Exile target artifact or enchantment.
+Oracle:Flying, lifelink\nAt the beginning of each end step, if you gained 3 or more life this turn, choose one —\n• Put a +1/+1 counter on Waxing Angel.\n• Exile target artifact or enchantment.


### PR DESCRIPTION
## Summary
- script HZN cards such as Demonbane Grenadier and Hexplate Companion
- add Lay Low, Protective Memory, Soul's Attendant, Tyriel, Waxing Angel, Eye of Dismay, and Invent the Future
- note: Kenleigh, Liege of Redemption requires future engine support for revive ability

## Testing
- `mvn -q -pl forge-gui -am test` *(fails: Plugin org.apache.maven.wagon:wagon-ftp:3.5.3 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_689443738c2c8320b2e9a548d6ce1e65