### PR TITLE
Add HZN custom card scripts and token

### DIFF
--- a/forge-gui/res/cardsfolder/HZN/Clean-Up_Crew.txt
+++ b/forge-gui/res/cardsfolder/HZN/Clean-Up_Crew.txt
@@ -1,0 +1,7 @@
+Name:Clean-Up Crew
+ManaCost:B
+Types:Creature Human
+PT:1/1
+A:AB$ Surveil | Cost$ Sac<1/Creature> | Amount$ 1 | SpellDescription$ Surveil 1. (Look at the top card of your library. You may put that card into your graveyard.)
+DeckHas:Ability$Surveil|Graveyard|Sacrifice
+Oracle:Sacrifice a creature: Surveil 1. (Look at the top card of your library. You may put that card into your graveyard.)

--- a/forge-gui/res/cardsfolder/HZN/Diviner_of_Blood.txt
+++ b/forge-gui/res/cardsfolder/HZN/Diviner_of_Blood.txt
@@ -1,0 +1,8 @@
+Name:Diviner of Blood
+ManaCost:1 B B
+Types:Creature Vampire Demon
+PT:2/2
+K:Flying
+S:Mode$ Continuous | Affected$ Creature.Demon+YouCtrl,Creature.Vampire+YouCtrl | AddPower$ X | AddToughness$ X | Description$ Demons and Vampires you control get +1/+1 for each player that has lost life this turn.
+SVar:X:PlayerCountPlayers$HasPropertyLostLifeThisTurn
+Oracle:Flying\nDemons and Vampires you control get +1/+1 for each player that has lost life this turn.

--- a/forge-gui/res/cardsfolder/HZN/Hunger.txt
+++ b/forge-gui/res/cardsfolder/HZN/Hunger.txt
@@ -1,0 +1,10 @@
+Name:Hunger
+ManaCost:3 B B
+Types:Creature Elemental Incarnation
+PT:4/3
+T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ Player.Opponent | TriggerZones$ Battlefield | Execute$ TrigLoseLifeCreature | TriggerDescription$ At the beginning of each opponent's end step, that player loses 1 life for each creature they control unless they sacrifice a creature. Then they lose 1 life for each card in their hand unless they discard a card.
+SVar:TrigLoseLifeCreature:DB$ LoseLife | Defined$ TriggeredPlayer | UnlessCost$ Sac<1/Creature> | UnlessPayer$ TriggeredPlayer | LifeAmount$ X | SubAbility$ DBLoseLifeHand
+SVar:DBLoseLifeHand:DB$ LoseLife | Defined$ TriggeredPlayer | UnlessCost$ Discard<1/Card> | UnlessPayer$ TriggeredPlayer | LifeAmount$ Y
+SVar:X:TriggeredPlayer$Valid Creature.YouCtrl
+SVar:Y:TriggeredPlayer$CardsInHand
+Oracle:At the beginning of each opponent's end step, that player loses 1 life for each creature they control unless they sacrifice a creature. Then they lose 1 life for each card in their hand unless they discard a card.

--- a/forge-gui/res/cardsfolder/HZN/Iterative_Design.txt
+++ b/forge-gui/res/cardsfolder/HZN/Iterative_Design.txt
@@ -1,0 +1,7 @@
+Name:Iterative Design
+ManaCost:1 U
+Types:Enchantment
+S:Mode$ Continuous | Affected$ Creature.Artifact+YouCtrl | AddPower$ 1 | AddToughness$ 1 | Description$ Artifact creatures you control get +1/+1.
+A:AB$ ChangeZone | Cost$ 1 U Discard<1/Artifact> | Origin$ Library | Destination$ Hand | ChangeType$ Artifact | ChangeNum$ 1 | SpellDescription$ Search your library for an artifact card, reveal it, put it into your hand, then shuffle.
+SVar:PlayMain1:TRUE
+Oracle:Artifact creatures you control get +1/+1.\n{1}{U}, Discard an artifact card: Search your library for an artifact card, reveal it, put it into your hand, then shuffle.

--- a/forge-gui/res/cardsfolder/HZN/Powder_Scatterer.txt
+++ b/forge-gui/res/cardsfolder/HZN/Powder_Scatterer.txt
@@ -1,0 +1,10 @@
+Name:Powder Scatterer
+ManaCost:1 U U
+Types:Creature Faerie Wizard
+PT:3/1
+K:Flash
+K:Flying
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigExile | TriggerDescription$ When CARDNAME enters, exile target noncreature spell. Its controller draws a card.
+SVar:TrigExile:DB$ ChangeZone | TargetType$ Spell | ValidTgts$ Card.nonCreature | TgtZone$ Stack | Origin$ Stack | Destination$ Exile | IsCurse$ True | TgtPrompt$ Choose target noncreature spell | SubAbility$ DBDraw
+SVar:DBDraw:DB$ Draw | Defined$ TargetedController | NumCards$ 1
+Oracle:Flash\nFlying\nWhen Powder Scatterer enters, exile target noncreature spell. Its controller draws a card.

--- a/forge-gui/res/cardsfolder/HZN/Project_Head.txt
+++ b/forge-gui/res/cardsfolder/HZN/Project_Head.txt
@@ -1,0 +1,10 @@
+Name:Project Head
+ManaCost:1 U
+Types:Creature Human Artificer
+PT:2/1
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigInvestigate | TriggerDescription$ When CARDNAME enters, investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+SVar:TrigInvestigate:DB$ Investigate
+A:AB$ ChangeZoneAll | Cost$ 2 U Exile<1/CARDNAME> | Origin$ Graveyard,Hand | Destination$ Library | ChangeType$ Card.YouOwn | Shuffle$ True | SubAbility$ DBDraw | IsPresent$ Artifact.YouCtrl | PresentCompare$ GE7 | SpellDescription$ Shuffle your hand and graveyard into your library, then draw seven cards. Activate only if you control seven or more artifacts.
+SVar:DBDraw:DB$ Draw | Defined$ You | NumCards$ 7
+DeckHas:Ability$Investigate|Token
+Oracle:When Project Head enters, investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")\n{2}{U}, Exile Project Head: Shuffle your hand and graveyard into your library, then draw seven cards. Activate only if you control seven or more artifacts.

--- a/forge-gui/res/cardsfolder/HZN/Reveal_Eternities.txt
+++ b/forge-gui/res/cardsfolder/HZN/Reveal_Eternities.txt
@@ -1,0 +1,7 @@
+Name:Reveal Eternities
+ManaCost:1 U
+Types:Instant
+A:SP$ Dig | DigNum$ 3 | DestinationZone2$ Graveyard | NoReveal$ True | SpellDescription$ Look at the top three cards of your library. Put one of them into your hand and the rest into your graveyard.
+K:Flashback:3 U
+AI:RemoveDeck:All
+Oracle:Look at the top three cards of your library. Put one of them into your hand and the rest into your graveyard.\nFlashback {3}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)

--- a/forge-gui/res/cardsfolder/HZN/Stormcaller_Sentinel.txt
+++ b/forge-gui/res/cardsfolder/HZN/Stormcaller_Sentinel.txt
@@ -1,0 +1,7 @@
+Name:Stormcaller Sentinel
+ManaCost:U U
+Types:Enchantment Deity
+K:Flying
+A:AB$ Animate | Cost$ 2 U U | Defined$ Self | Power$ 3 | Toughness$ 3 | Types$ Creature,Drake | Keywords$ Flying | Duration$ Permanent | PrecostDesc$ Beckon Drake — | SpellDescription$ CARDNAME becomes a 3/3 Drake creature with flying in addition to its other types.
+S:Mode$ Continuous | Affected$ Creature.withFlying+YouCtrl+Other | AddPower$ 1 | AddToughness$ 1 | Description$ Other creatures you control with flying get +1/+1.
+Oracle:Beckon Drake {2}{U}{U} ({2}{U}{U}: This noncreature Deity permanently becomes a Drake creature in addition to its other types.)\nFlying\nOther creatures you control with flying get +1/+1.\n3/3

--- a/forge-gui/res/cardsfolder/HZN/Wave_Racer.txt
+++ b/forge-gui/res/cardsfolder/HZN/Wave_Racer.txt
@@ -1,0 +1,9 @@
+Name:Wave Racer
+ManaCost:U U
+Types:Creature Merfolk Wizard
+PT:2/1
+S:Mode$ Continuous | Affected$ Creature.Merfolk+YouCtrl+Other,Creature.Elemental+YouCtrl+Other | AddPower$ 1 | AddToughness$ 1 | Description$ Each other creature you control that's a Merfolk or an Elemental gets +1/+1.
+T:Mode$ SpellCast | ValidCard$ Instant,Sorcery,Merfolk | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | OptionalDecider$ You | Execute$ TrigToken | TriggerDescription$ Whenever you cast an instant, sorcery, or Merfolk spell, you may pay {1}. If you do, create a 1/0 blue Elemental creature token.
+SVar:TrigToken:AB$ Token | Cost$ 1 | TokenAmount$ 1 | TokenScript$ u_1_0_elemental | TokenOwner$ You
+DeckHas:Ability$Token & Type$Elemental
+Oracle:Each other creature you control that's a Merfolk or an Elemental gets +1/+1.\nWhenever you cast an instant, sorcery, or Merfolk spell, you may pay {1}. If you do, create a 1/0 blue Elemental creature token.

--- a/forge-gui/res/cardsfolder/HZN/Willow_Spirit.txt
+++ b/forge-gui/res/cardsfolder/HZN/Willow_Spirit.txt
@@ -1,0 +1,7 @@
+Name:Willow Spirit
+ManaCost:U
+Types:Creature Spirit
+PT:1/1
+K:Flying
+A:AB$ Counter | Cost$ U Sac<1/CARDNAME> | TargetType$ Spell,Activated,Triggered | TgtPrompt$ Choose target spell or ability that targets you or a creature you control | ValidTgts$ Card,Emblem | TargetValidTargeting$ Creature.YouCtrl+inRealZoneBattlefield,You | SpellDescription$ Counter target spell or ability that targets you or a creature you control.
+Oracle:Flying\n{U}, Sacrifice Willow Spirit: Counter target spell or ability that targets you or a creature you control.

--- a/forge-gui/res/tokenscripts/HZN/u_1_0_elemental.txt
+++ b/forge-gui/res/tokenscripts/HZN/u_1_0_elemental.txt
@@ -1,0 +1,6 @@
+Name:Elemental Token
+ManaCost:no cost
+Colors:blue
+Types:Creature Elemental
+PT:1/0
+Oracle:


### PR DESCRIPTION
## Summary
- add custom HZN card scripts including tutoring enchantment, counterspell faerie, and artifact-heavy artificer
- script blue instant with flashback and Deity that beckons into a Drake and pumps flyers
- include token generation support and additional blue/black creature designs

## Testing
- `mvn -q test` *(fails: Unresolveable build extension org.apache.maven.wagon:wagon-ftp:3.5.3)*

------
https://chatgpt.com/codex/tasks/task_e_6894512bbbb88320aeefd5dea8f04bde