### PR TITLE
Add HZN custom card scripts

### DIFF
--- a/forge-gui/res/cardsfolder/HZN/brutal_blow.txt
+++ b/forge-gui/res/cardsfolder/HZN/brutal_blow.txt
@@ -1,0 +1,6 @@
+Name:Brutal Blow
+ManaCost:R
+Types:Sorcery
+A:SP$ Destroy | ValidTgts$ Artifact | TgtPrompt$ Select target artifact | SpellDescription$ Destroy target artifact.
+# Reprise ability not implemented. Requires engine support.
+Oracle:Destroy target artifact.\nReprise {R} (As you cast an instant or sorcery spell, you may exile one card with reprise from your graveyard and pay its reprise cost. If you do, add its effects to that spell.)

--- a/forge-gui/res/cardsfolder/HZN/brutal_blow.txt
+++ b/forge-gui/res/cardsfolder/HZN/brutal_blow.txt
@@ -2,5 +2,6 @@ Name:Brutal Blow
 ManaCost:R
 Types:Sorcery
 A:SP$ Destroy | ValidTgts$ Artifact | TgtPrompt$ Select target artifact | SpellDescription$ Destroy target artifact.
-# Reprise ability not implemented. Requires engine support.
+T:Mode$ SpellCast | ValidCard$ Instant,Sorcery | ValidActivatingPlayer$ You | TriggerZones$ Graveyard | Execute$ TrigReprise | OptionalDecider$ You | TriggerDescription$ Reprise {R} — Whenever you cast an instant or sorcery spell, you may pay {R} and exile CARDNAME from your graveyard. If you do, add this card's effects to that spell.
+SVar:TrigReprise:AB$ Destroy | Cost$ R ExileFromGrave<1/CARDNAME> | ValidTgts$ Artifact | TgtPrompt$ Select target artifact | SpellDescription$ Destroy target artifact.
 Oracle:Destroy target artifact.\nReprise {R} (As you cast an instant or sorcery spell, you may exile one card with reprise from your graveyard and pay its reprise cost. If you do, add its effects to that spell.)

--- a/forge-gui/res/cardsfolder/HZN/flamedaunt_courier.txt
+++ b/forge-gui/res/cardsfolder/HZN/flamedaunt_courier.txt
@@ -1,0 +1,9 @@
+Name:Flamedaunt Courier
+ManaCost:1 R
+Types:Creature Human Knight
+PT:2/1
+K:First Strike
+K:Haste
+T:Mode$ SpellCast | ValidCard$ Instant,Sorcery | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigPump | TriggerDescription$ Whenever you cast an instant or sorcery spell, CARDNAME gets +2/+0 until end of turn.
+SVar:TrigPump:DB$ Pump | Defined$ Self | NumAtt$ +2 | NumDef$ 0
+Oracle:First strike, haste\nWhenever you cast an instant or sorcery spell, Flamedaunt Courier gets +2/+0 until end of turn.

--- a/forge-gui/res/cardsfolder/HZN/flamedaunt_courier.txt
+++ b/forge-gui/res/cardsfolder/HZN/flamedaunt_courier.txt
@@ -1,7 +1,7 @@
 Name:Flamedaunt Courier
 ManaCost:1 R
 Types:Creature Human Knight
-PT:2/1
+PT:1/1
 K:First Strike
 K:Haste
 T:Mode$ SpellCast | ValidCard$ Instant,Sorcery | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigPump | TriggerDescription$ Whenever you cast an instant or sorcery spell, CARDNAME gets +2/+0 until end of turn.

--- a/forge-gui/res/cardsfolder/HZN/forked_pillar.txt
+++ b/forge-gui/res/cardsfolder/HZN/forked_pillar.txt
@@ -1,0 +1,7 @@
+Name:Forked Pillar
+ManaCost:R
+Types:Sorcery
+A:SP$ DealDamage | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ 2 | SubAbility$ DBDelayedTrigger | SpellDescription$ CARDNAME deals 2 damage to target creature. When that creature dies this turn, CARDNAME deals 1 damage to that creature's controller.
+SVar:DBDelayedTrigger:DB$ DelayedTrigger | Mode$ ChangesZone | RememberObjects$ Targeted | ValidCard$ Card.IsTriggerRemembered | Origin$ Battlefield | Destination$ Graveyard | ThisTurn$ True | Execute$ DBDamage | SpellDescription$ When that creature dies this turn, CARDNAME deals 1 damage to that creature's controller.
+SVar:DBDamage:DB$ DealDamage | Defined$ RememberedController | NumDmg$ 1
+Oracle:Forked Pillar deals 2 damage to target creature. When that creature dies this turn, Forked Pillar deals 1 damage to that creature's controller.

--- a/forge-gui/res/cardsfolder/HZN/forked_pillar.txt
+++ b/forge-gui/res/cardsfolder/HZN/forked_pillar.txt
@@ -3,5 +3,5 @@ ManaCost:R
 Types:Sorcery
 A:SP$ DealDamage | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ 2 | SubAbility$ DBDelayedTrigger | SpellDescription$ CARDNAME deals 2 damage to target creature. When that creature dies this turn, CARDNAME deals 1 damage to that creature's controller.
 SVar:DBDelayedTrigger:DB$ DelayedTrigger | Mode$ ChangesZone | RememberObjects$ Targeted | ValidCard$ Card.IsTriggerRemembered | Origin$ Battlefield | Destination$ Graveyard | ThisTurn$ True | Execute$ DBDamage | SpellDescription$ When that creature dies this turn, CARDNAME deals 1 damage to that creature's controller.
-SVar:DBDamage:DB$ DealDamage | Defined$ RememberedController | NumDmg$ 1
+SVar:DBDamage:DB$ DealDamage | Defined$ TriggeredCardController | NumDmg$ 1
 Oracle:Forked Pillar deals 2 damage to target creature. When that creature dies this turn, Forked Pillar deals 1 damage to that creature's controller.

--- a/forge-gui/res/cardsfolder/HZN/gold_retriever.txt
+++ b/forge-gui/res/cardsfolder/HZN/gold_retriever.txt
@@ -1,0 +1,12 @@
+Name:Gold Retriever
+ManaCost:4 R R
+Types:Creature Dragon Hound
+PT:4/4
+S:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ X | EffectZone$ All | Description$ This spell costs {1} less to cast for each permanent you control that's a Dragon or a Hound.
+SVar:X:Count$Valid Permanent.YouCtrl+Dragon,Permanent.YouCtrl+Hound
+K:Flying
+K:Haste
+SVar:Bound:Count$CardManaCost
+T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigAbound | TriggerDescription$ Whenever CARDNAME attacks, abound. (You may cast a nonland card that costs less than this from your hand without paying its mana cost.)
+SVar:TrigAbound:DB$ Play | Valid$ Card.nonLand+cmcLTBound | ValidZone$ Hand | WithoutManaCost$ True | Amount$ 1 | Optional$ True | Controller$ You
+Oracle:This spell costs {1} less to cast for each permanent you control that's a Dragon or a Hound.\nFlying, haste\nWhenever Gold Retriever attacks, abound. (You may cast a nonland card that costs less than this from your hand without paying its mana cost.)

--- a/forge-gui/res/cardsfolder/HZN/gold_retriever.txt
+++ b/forge-gui/res/cardsfolder/HZN/gold_retriever.txt
@@ -8,5 +8,5 @@ K:Flying
 K:Haste
 SVar:Bound:Count$CardManaCost
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigAbound | TriggerDescription$ Whenever CARDNAME attacks, abound. (You may cast a nonland card that costs less than this from your hand without paying its mana cost.)
-SVar:TrigAbound:DB$ Play | Valid$ Card.nonLand+cmcLTBound | ValidZone$ Hand | WithoutManaCost$ True | Amount$ 1 | Optional$ True | Controller$ You
+SVar:TrigAbound:DB$ Play | Valid$ Card.nonLand+cmcLTBound+YouOwn | ValidZone$ Hand | WithoutManaCost$ True | Amount$ 1 | Optional$ True | Controller$ You
 Oracle:This spell costs {1} less to cast for each permanent you control that's a Dragon or a Hound.\nFlying, haste\nWhenever Gold Retriever attacks, abound. (You may cast a nonland card that costs less than this from your hand without paying its mana cost.)

--- a/forge-gui/res/cardsfolder/HZN/grin_scourge_of_goresand.txt
+++ b/forge-gui/res/cardsfolder/HZN/grin_scourge_of_goresand.txt
@@ -4,5 +4,6 @@ Types:Legendary Creature Human Berserker
 PT:3/3
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigDelayed | TriggerDescription$ Whenever CARDNAME attacks, when you next cast an instant or sorcery spell with mana value 3 or less this turn, copy that spell. You may choose new targets for the copy.
 SVar:TrigDelayed:DB$ DelayedTrigger | AILogic$ SpellCopy | Mode$ SpellCast | ValidCard$ Instant.cmcLE3,Sorcery.cmcLE3 | ValidActivatingPlayer$ You | Execute$ EffTrigCopy | ThisTurn$ True
+SVar:EffTrigCopy:DB$ CopySpellAbility | Defined$ TriggeredSpellAbility | MayChooseTarget$ True
 K:Dash:2 R
 Oracle:Whenever Grin, Scourge of Goresand attacks, when you next cast an instant or sorcery spell with mana value 3 or less this turn, copy that spell. You may choose new targets for the copy.\nDash {2}{R} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)

--- a/forge-gui/res/cardsfolder/HZN/grin_scourge_of_goresand.txt
+++ b/forge-gui/res/cardsfolder/HZN/grin_scourge_of_goresand.txt
@@ -1,0 +1,8 @@
+Name:Grin, Scourge of Goresand
+ManaCost:1 R R
+Types:Legendary Creature Human Berserker
+PT:3/3
+T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigDelayed | TriggerDescription$ Whenever CARDNAME attacks, when you next cast an instant or sorcery spell with mana value 3 or less this turn, copy that spell. You may choose new targets for the copy.
+SVar:TrigDelayed:DB$ DelayedTrigger | AILogic$ SpellCopy | Mode$ SpellCast | ValidCard$ Instant.cmcLE3,Sorcery.cmcLE3 | ValidActivatingPlayer$ You | Execute$ EffTrigCopy | ThisTurn$ True
+K:Dash:2 R
+Oracle:Whenever Grin, Scourge of Goresand attacks, when you next cast an instant or sorcery spell with mana value 3 or less this turn, copy that spell. You may choose new targets for the copy.\nDash {2}{R} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)

--- a/forge-gui/res/cardsfolder/HZN/inescapable_fate.txt
+++ b/forge-gui/res/cardsfolder/HZN/inescapable_fate.txt
@@ -1,7 +1,7 @@
 Name:Inescapable Fate
 ManaCost:1 B
 Types:Instant
-A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ -1 | NumDef$ -1 | SubAbility$ DBDestroy | SpellDescription$ Target creature gets -1/-1 until end of turn.
-SVar:DBDestroy:DB$ Destroy | Defined$ Targeted | Optional$ True | ConditionCheckSVar$ X | ConditionSVarCompare$ GE7 | SpellDescription$ Threshold — You may destroy that creature instead if seven or more cards are in your graveyard.
+A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | RememberTargets$ True | NumAtt$ -1 | NumDef$ -1 | SpellDescription$ Target creature gets -1/-1 until end of turn.
+A:SP$ Destroy | ValidTgts$ Creature | CheckSVar$ X | SVarCompare$ GE7 | SpellDescription$ Threshold — You may destroy that creature instead if seven or more cards are in your graveyard.
 SVar:X:Count$ValidGraveyard Card.YouOwn
 Oracle:Target creature gets -1/-1 until end of turn.\nThreshold — You may destroy that creature instead if seven or more cards are in your graveyard.

--- a/forge-gui/res/cardsfolder/HZN/inescapable_fate.txt
+++ b/forge-gui/res/cardsfolder/HZN/inescapable_fate.txt
@@ -1,0 +1,7 @@
+Name:Inescapable Fate
+ManaCost:1 B
+Types:Instant
+A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ -1 | NumDef$ -1 | SubAbility$ DBDestroy | SpellDescription$ Target creature gets -1/-1 until end of turn.
+SVar:DBDestroy:DB$ Destroy | Defined$ Targeted | Optional$ True | ConditionCheckSVar$ X | ConditionSVarCompare$ GE7 | SpellDescription$ Threshold — You may destroy that creature instead if seven or more cards are in your graveyard.
+SVar:X:Count$ValidGraveyard Card.YouOwn
+Oracle:Target creature gets -1/-1 until end of turn.\nThreshold — You may destroy that creature instead if seven or more cards are in your graveyard.

--- a/forge-gui/res/cardsfolder/HZN/mind_pryer.txt
+++ b/forge-gui/res/cardsfolder/HZN/mind_pryer.txt
@@ -1,0 +1,12 @@
+Name:Mind-Pryer
+ManaCost:B B
+Types:Creature Demon
+PT:2/1
+K:Lifelink
+S:Mode$ Continuous | Affected$ Card.Self | AddPower$ 1 | AddToughness$ 1 | CheckSVar$ HandCount | SVarCompare$ LE1 | Description$ CARDNAME gets +1/+1 as long as an opponent has one or fewer cards in hand.
+SVar:HandCount:PlayerCountOpponents$LowestCardsInHand
+T:Mode$ Discarded | ValidCard$ Card.OppOwn | TriggerZones$ Battlefield | IsPresent$ Card.Self+withMenace | PresentCompare$ EQ0 | Execute$ TrigCounter | TriggerDescription$ Whenever an opponent discards a card, CARDNAME cackles. (Put a menace counter on it. If it already has menace, it deals 1 damage to each opponent instead.)
+SVar:TrigCounter:DB$ PutCounter | Defined$ Self | CounterType$ Menace | CounterNum$ 1
+T:Mode$ Discarded | ValidCard$ Card.OppOwn | TriggerZones$ Battlefield | IsPresent$ Card.Self+withMenace | PresentCompare$ GE1 | Execute$ TrigDamage | Secondary$ True
+SVar:TrigDamage:DB$ DealDamage | ValidTgts$ Opponent | NumDmg$ 1
+Oracle:Lifelink\nMind-Pryer gets +1/+1 as long as an opponent has one or fewer cards in hand.\nWhenever an opponent discards a card, Mind-Pryer cackles. (Put a menace counter on it. If it already has menace, it deals 1 damage to each opponent instead.)

--- a/forge-gui/res/cardsfolder/HZN/night_of_the_unliving.txt
+++ b/forge-gui/res/cardsfolder/HZN/night_of_the_unliving.txt
@@ -1,0 +1,7 @@
+Name:Night of the Unliving
+ManaCost:2 B B
+Types:Enchantment
+T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | CheckSVar$ NCards | SVarCompare$ EQ0 | Execute$ TrigReturn | Optional$ True | TriggerDescription$ At the beginning of your upkeep, if there are no noncreature cards in your graveyard, you may return target creature card from your graveyard to the battlefield.
+SVar:TrigReturn:DB$ ChangeZone | Origin$ Graveyard | Destination$ Battlefield | ValidTgts$ Creature.YouOwn | TgtPrompt$ Select target creature card in your graveyard | Optional$ True
+SVar:NCards:Count$ValidGraveyard Card.nonCreature+YouOwn
+Oracle:At the beginning of your upkeep, if there are no noncreature cards in your graveyard, you may return target creature card from your graveyard to the battlefield.

--- a/forge-gui/res/cardsfolder/HZN/night_of_the_unliving.txt
+++ b/forge-gui/res/cardsfolder/HZN/night_of_the_unliving.txt
@@ -1,7 +1,0 @@
-Name:Night of the Unliving
-ManaCost:2 B B
-Types:Enchantment
-T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | CheckSVar$ NCards | SVarCompare$ EQ0 | Execute$ TrigReturn | Optional$ True | TriggerDescription$ At the beginning of your upkeep, if there are no noncreature cards in your graveyard, you may return target creature card from your graveyard to the battlefield.
-SVar:TrigReturn:DB$ ChangeZone | Origin$ Graveyard | Destination$ Battlefield | ValidTgts$ Creature.YouOwn | TgtPrompt$ Select target creature card in your graveyard | Optional$ True
-SVar:NCards:Count$ValidGraveyard Card.nonCreature+YouOwn
-Oracle:At the beginning of your upkeep, if there are no noncreature cards in your graveyard, you may return target creature card from your graveyard to the battlefield.

--- a/forge-gui/res/cardsfolder/HZN/noxious_upwelling.txt
+++ b/forge-gui/res/cardsfolder/HZN/noxious_upwelling.txt
@@ -1,0 +1,7 @@
+Name:Noxious Upwelling
+ManaCost:1 B B
+Types:Sorcery
+K:Kicker:Sac<1/Swamp>
+A:SP$ PumpAll | ValidCards$ Creature | NumAtt$ -2 | NumDef$ -2 | SubAbility$ DBCopy | SpellDescription$ All creatures get -2/-2 until end of turn.
+SVar:DBCopy:DB$ CopySpellAbility | Defined$ Self | Condition$ Kicked | SpellDescription$ Reverberate — Sacrifice a Swamp. (When you cast this spell, copy it if you paid its reverberate cost.)
+Oracle:Reverberate—Sacrifice a Swamp. (When you cast this spell, copy it if you paid its reverberate cost.)\nAll creatures get -2/-2 until end of turn.

--- a/forge-gui/res/cardsfolder/HZN/noxious_upwelling.txt
+++ b/forge-gui/res/cardsfolder/HZN/noxious_upwelling.txt
@@ -1,7 +1,9 @@
 Name:Noxious Upwelling
 ManaCost:1 B B
 Types:Sorcery
-K:Kicker:Sac<1/Swamp>
-A:SP$ PumpAll | ValidCards$ Creature | NumAtt$ -2 | NumDef$ -2 | SubAbility$ DBCopy | SpellDescription$ All creatures get -2/-2 until end of turn.
-SVar:DBCopy:DB$ CopySpellAbility | Defined$ Self | Condition$ Kicked | SpellDescription$ Reverberate — Sacrifice a Swamp. (When you cast this spell, copy it if you paid its reverberate cost.)
+S:Mode$ AlternativeCost | ValidSA$ Spell.Self | EffectZone$ All | Cost$ 1 B B Sac<1/Swamp> | Description$ Reverberate — Sacrifice a Swamp. (When you cast this spell, copy it if you paid its reverberate cost.)
+A:SP$ PumpAll | ValidCards$ Creature | NumAtt$ -2 | NumDef$ -2 | SpellDescription$ All creatures get -2/-2 until end of turn.
+T:Mode$ SpellCast | ValidCard$ Card.Self | Execute$ TrigCopy | CheckSVar$ AltCostPaid | SVarCompare$ GE1
+SVar:TrigCopy:DB$ CopySpellAbility | Defined$ TriggeredSpellAbility
+SVar:AltCostPaid:Count$AltCost.1.0
 Oracle:Reverberate—Sacrifice a Swamp. (When you cast this spell, copy it if you paid its reverberate cost.)\nAll creatures get -2/-2 until end of turn.

--- a/forge-gui/res/cardsfolder/HZN/void_portal.txt
+++ b/forge-gui/res/cardsfolder/HZN/void_portal.txt
@@ -1,0 +1,6 @@
+Name:Void Portal
+ManaCost:2 B
+Types:Enchantment
+A:AB$ ChangeZone | Cost$ Discard<1/Card> | Origin$ Library | Destination$ Hand | ChangeType$ Card.cmcEQX | ChangeNum$ 1 | Reveal$ True | Shuffle$ True | SorcerySpeed$ True | ActivationLimit$ 1 | SpellDescription$ Discard a card: Search your library for a card with the same mana value as the discarded card, reveal it, put it into your hand, then shuffle. Activate only as a sorcery and only once each turn.
+SVar:X:Discarded$CardManaCost
+Oracle:Discard a card: Search your library for a card with the same mana value as the discarded card, reveal it, put it into your hand, then shuffle. Activate only as a sorcery and only once each turn.


### PR DESCRIPTION
## Summary
- add Inescapable Fate instant with threshold destroy option
- implement Mind-Pryer demon with menace counter cackling
- script remaining HZN cards including Gold Retriever, Grin, Scourge of Goresand, and more

## Testing
- `mvn -q -pl forge-gui -am test` *(fails: Unresolveable build extension: Plugin org.apache.maven.wagon:wagon-ftp:3.5.3)*

------
https://chatgpt.com/codex/tasks/task_e_689458b3818c8320b245c67869c5d1aa