### PR TITLE
Add HZN custom card scripts and tokens

### DIFF
--- a/forge-gui/res/cardsfolder/HZN/camahueto_calf.txt
+++ b/forge-gui/res/cardsfolder/HZN/camahueto_calf.txt
@@ -1,0 +1,6 @@
+Name:Camahueto Calf
+ManaCost:G
+Types:Creature Ox
+PT:1/1
+A:AB$ ChangeZone | Cost$ T Sac<1/CARDNAME> | ValidTgts$ Land.YouGraveyard | TgtPrompt$ Select target land card in your graveyard | Origin$ Graveyard | Destination$ Battlefield | SpellDescription$ Return target land card from your graveyard to the battlefield.
+Oracle:{T}, Sacrifice CARDNAME: Return target land card from your graveyard to the battlefield.

--- a/forge-gui/res/cardsfolder/HZN/camahueto_calf.txt
+++ b/forge-gui/res/cardsfolder/HZN/camahueto_calf.txt
@@ -2,5 +2,5 @@ Name:Camahueto Calf
 ManaCost:G
 Types:Creature Ox
 PT:1/1
-A:AB$ ChangeZone | Cost$ T Sac<1/CARDNAME> | ValidTgts$ Land.YouGraveyard | TgtPrompt$ Select target land card in your graveyard | Origin$ Graveyard | Destination$ Battlefield | SpellDescription$ Return target land card from your graveyard to the battlefield.
+A:AB$ ChangeZone | Cost$ T Sac<1/CARDNAME> | Origin$ Graveyard | Destination$ Battlefield | TgtPrompt$ Select target land card in your graveyard | ValidTgts$ Land.YouOwn | SpellDescription$ Return target land card from your graveyard to the battlefield.
 Oracle:{T}, Sacrifice CARDNAME: Return target land card from your graveyard to the battlefield.

--- a/forge-gui/res/cardsfolder/HZN/dazzling_dreamspinner.txt
+++ b/forge-gui/res/cardsfolder/HZN/dazzling_dreamspinner.txt
@@ -1,0 +1,7 @@
+Name:Dazzling Dreamspinner
+ManaCost:1 G G
+Types:Creature Elf Druid
+PT:2/2
+A:AB$ Mana | Cost$ tapXType<2/Elf> | Produced$ G | Amount$ 2 | SpellDescription$ Add {G}{G}.
+A:AB$ Token | Cost$ 6 G G | TokenAmount$ 1 | TokenScript$ HZN/g_8_8_elemental | TokenOwner$ You | SpellDescription$ Create an 8/8 green Elemental creature token.
+Oracle:Tap two untapped Elves you control: Add {G}{G}.\n{6}{G}{G}: Create an 8/8 green Elemental creature token.

--- a/forge-gui/res/cardsfolder/HZN/dazzling_dreamspinner.txt
+++ b/forge-gui/res/cardsfolder/HZN/dazzling_dreamspinner.txt
@@ -3,5 +3,5 @@ ManaCost:1 G G
 Types:Creature Elf Druid
 PT:2/2
 A:AB$ Mana | Cost$ tapXType<2/Elf> | Produced$ G | Amount$ 2 | SpellDescription$ Add {G}{G}.
-A:AB$ Token | Cost$ 6 G G | TokenAmount$ 1 | TokenScript$ HZN/g_8_8_elemental | TokenOwner$ You | SpellDescription$ Create an 8/8 green Elemental creature token.
+A:AB$ Token | Cost$ 6 G G | TokenAmount$ 1 | TokenScript$ g_8_8_elemental | TokenOwner$ You | SpellDescription$ Create an 8/8 green Elemental creature token.
 Oracle:Tap two untapped Elves you control: Add {G}{G}.\n{6}{G}{G}: Create an 8/8 green Elemental creature token.

--- a/forge-gui/res/cardsfolder/HZN/duskwood_revolutionary.txt
+++ b/forge-gui/res/cardsfolder/HZN/duskwood_revolutionary.txt
@@ -1,0 +1,8 @@
+Name:Duskwood Revolutionary
+ManaCost:G G
+Types:Creature Elf Warrior
+PT:2/2
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | TriggerZones$ Battlefield | ValidCard$ Creature.YouCtrl+Other+!Token+Elf,Warrior | Execute$ TrigPutCounter | TriggerDescription$ Each other nontoken Elf and/or Warrior you control enters with an additional +1/+1 counter on it.
+SVar:TrigPutCounter:DB$ PutCounter | Defined$ TriggeredCard | CounterType$ P1P1 | CounterNum$ 1
+A:AB$ Token | Cost$ G G T SubCounter<2/P1P1/Creature/creature you control> | TokenAmount$ 2 | TokenScript$ g_1_1_elf_warrior | TokenOwner$ You | SpellDescription$ Create two 1/1 green Elf Warrior creature tokens.
+Oracle:Each other nontoken Elf and/or Warrior you control enters with an additional +1/+1 counter on it.\n{G}{G}, {T}, Remove two +1/+1 counters from among creatures you control: Create two 1/1 green Elf Warrior creature tokens.

--- a/forge-gui/res/cardsfolder/HZN/duskwood_revolutionary.txt
+++ b/forge-gui/res/cardsfolder/HZN/duskwood_revolutionary.txt
@@ -2,7 +2,7 @@ Name:Duskwood Revolutionary
 ManaCost:G G
 Types:Creature Elf Warrior
 PT:2/2
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | TriggerZones$ Battlefield | ValidCard$ Creature.YouCtrl+Other+!Token+Elf,Warrior | Execute$ TrigPutCounter | TriggerDescription$ Each other nontoken Elf and/or Warrior you control enters with an additional +1/+1 counter on it.
-SVar:TrigPutCounter:DB$ PutCounter | Defined$ TriggeredCard | CounterType$ P1P1 | CounterNum$ 1
-A:AB$ Token | Cost$ G G T SubCounter<2/P1P1/Creature/creature you control> | TokenAmount$ 2 | TokenScript$ g_1_1_elf_warrior | TokenOwner$ You | SpellDescription$ Create two 1/1 green Elf Warrior creature tokens.
+K:ETBReplacement:Other:AddExtraCounter:Mandatory:Battlefield:Creature.Other+YouCtrl+!token+Elf,Creature.Other+YouCtrl+!token+Warrior
+SVar:AddExtraCounter:DB$ PutCounter | ETB$ True | Defined$ ReplacedCard | CounterType$ P1P1 | CounterNum$ 1 | SpellDescription$ Each other nontoken Elf and/or Warrior you control enters with an additional +1/+1 counter on it.
+A:AB$ Token | Cost$ G G T RemoveAnyCounter<2/P1P1/Creature.YouCtrl/among creatures you control> | TokenAmount$ 2 | TokenScript$ g_1_1_elf_warrior | TokenOwner$ You | SpellDescription$ Create two 1/1 green Elf Warrior creature tokens.
 Oracle:Each other nontoken Elf and/or Warrior you control enters with an additional +1/+1 counter on it.\n{G}{G}, {T}, Remove two +1/+1 counters from among creatures you control: Create two 1/1 green Elf Warrior creature tokens.

--- a/forge-gui/res/cardsfolder/HZN/evaldis_muse.txt
+++ b/forge-gui/res/cardsfolder/HZN/evaldis_muse.txt
@@ -1,0 +1,9 @@
+Name:Evaldi's Muse
+ManaCost:2 G G
+Types:Creature Wurm
+PT:4/3
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | TriggerZones$ Battlefield | ValidCard$ Creature.YouCtrl+!Token | Execute$ TrigGain | TriggerDescription$ Whenever CARDNAME or another nontoken creature you control enters, you gain 2 life.
+SVar:TrigGain:DB$ GainLife | DefinedPlayer$ You | LifeAmount$ 2
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Any | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME leaves the battlefield, create two 1/1 green and blue Elf creature tokens.
+SVar:TrigToken:DB$ Token | TokenAmount$ 2 | TokenScript$ HZN/gu_1_1_elf | TokenOwner$ You
+Oracle:Whenever CARDNAME or another nontoken creature you control enters, you gain 2 life.\nWhen CARDNAME leaves the battlefield, create two 1/1 green and blue Elf creature tokens.

--- a/forge-gui/res/cardsfolder/HZN/evaldis_muse.txt
+++ b/forge-gui/res/cardsfolder/HZN/evaldis_muse.txt
@@ -5,5 +5,5 @@ PT:4/3
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | TriggerZones$ Battlefield | ValidCard$ Creature.YouCtrl+!Token | Execute$ TrigGain | TriggerDescription$ Whenever CARDNAME or another nontoken creature you control enters, you gain 2 life.
 SVar:TrigGain:DB$ GainLife | DefinedPlayer$ You | LifeAmount$ 2
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Any | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME leaves the battlefield, create two 1/1 green and blue Elf creature tokens.
-SVar:TrigToken:DB$ Token | TokenAmount$ 2 | TokenScript$ HZN/gu_1_1_elf | TokenOwner$ You
+SVar:TrigToken:DB$ Token | TokenAmount$ 2 | TokenScript$ gu_1_1_elf | TokenOwner$ You
 Oracle:Whenever CARDNAME or another nontoken creature you control enters, you gain 2 life.\nWhen CARDNAME leaves the battlefield, create two 1/1 green and blue Elf creature tokens.

--- a/forge-gui/res/cardsfolder/HZN/horizon_wayfarer.txt
+++ b/forge-gui/res/cardsfolder/HZN/horizon_wayfarer.txt
@@ -1,0 +1,7 @@
+Name:Horizon Wayfarer
+ManaCost:1 G
+Types:Creature Elf Scout
+PT:*/*
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of differently named lands you control.
+SVar:X:Count$DifferentCardNames_Land.YouCtrl+inZoneBattlefield
+Oracle:CARDNAME's power and toughness are each equal to the number of differently named lands you control.

--- a/forge-gui/res/cardsfolder/HZN/horizon_wayfarer.txt
+++ b/forge-gui/res/cardsfolder/HZN/horizon_wayfarer.txt
@@ -4,4 +4,4 @@ Types:Creature Elf Scout
 PT:*/*
 S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of differently named lands you control.
 SVar:X:Count$DifferentCardNames_Land.YouCtrl+inZoneBattlefield
-Oracle:CARDNAME's power and toughness are each equal to the number of differently named lands you control.
+Oracle:Horizon Wayfarer's power and toughness are each equal to the number of differently named lands you control.

--- a/forge-gui/res/cardsfolder/HZN/mystery_of_the_crashed_craft_epsilon_crash_captain.txt
+++ b/forge-gui/res/cardsfolder/HZN/mystery_of_the_crashed_craft_epsilon_crash_captain.txt
@@ -2,7 +2,7 @@ Name:Mystery of the Crashed Craft
 ManaCost:1 R
 Types:Enchantment Mystery
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters, create two 1/1 red Alien creature tokens with "This creature can't block."
-SVar:TrigToken:DB$ Token | TokenScript$ HZN/r_1_1_alien_noblock | TokenAmount$ 2 | TokenOwner$ You
+SVar:TrigToken:DB$ Token | TokenScript$ r_1_1_alien_noblock | TokenAmount$ 2 | TokenOwner$ You
 T:Mode$ SpellCast | ValidCard$ Instant | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | IsPresent$ Card.Self+counters_GE1_INST | PresentCompare$ EQ0 | Execute$ DecodeInst | TriggerDescription$ Condition — You cast an instant spell.
 SVar:DecodeInst:DB$ PutCounter | Defined$ Self | CounterType$ INST | CounterNum$ 1 | SubAbility$ CheckSolve
 T:Mode$ SpellCast | ValidCard$ Sorcery | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | IsPresent$ Card.Self+counters_GE1_SOR | PresentCompare$ EQ0 | Execute$ DecodeSor | TriggerDescription$ Condition — You cast a sorcery spell.
@@ -19,6 +19,6 @@ Colors:red
 Types:Legendary Creature Alien
 PT:2/2
 T:Mode$ SpellCast | ValidCard$ Instant,Sorcery | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ Whenever you cast an instant or sorcery spell, create a 1/1 red Alien creature token with "This creature can't block."
-SVar:TrigToken:DB$ Token | TokenScript$ HZN/r_1_1_alien_noblock | TokenAmount$ 1 | TokenOwner$ You
+SVar:TrigToken:DB$ Token | TokenScript$ r_1_1_alien_noblock | TokenAmount$ 1 | TokenOwner$ You
 A:AB$ CopySpellAbility | Cost$ 2 R Sac<2/Alien> | ValidTgts$ Instant.YouCtrl,Sorcery.YouCtrl | TargetType$ Spell | MayChooseTarget$ True | SpellDescription$ Copy target instant or sorcery spell you control. You may choose new targets for the copy.
 Oracle:Whenever you cast an instant or sorcery spell, create a 1/1 red Alien creature token with "This creature can't block."\n{2}{R}, Sacrifice two Aliens: Copy target instant or sorcery spell you control. You may choose new targets for the copy.

--- a/forge-gui/res/cardsfolder/HZN/mystery_of_the_crashed_craft_epsilon_crash_captain.txt
+++ b/forge-gui/res/cardsfolder/HZN/mystery_of_the_crashed_craft_epsilon_crash_captain.txt
@@ -1,0 +1,24 @@
+Name:Mystery of the Crashed Craft
+ManaCost:1 R
+Types:Enchantment Mystery
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters, create two 1/1 red Alien creature tokens with "This creature can't block."
+SVar:TrigToken:DB$ Token | TokenScript$ HZN/r_1_1_alien_noblock | TokenAmount$ 2 | TokenOwner$ You
+T:Mode$ SpellCast | ValidCard$ Instant | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | IsPresent$ Card.Self+counters_GE1_INST | PresentCompare$ EQ0 | Execute$ DecodeInst | TriggerDescription$ Condition — You cast an instant spell.
+SVar:DecodeInst:DB$ PutCounter | Defined$ Self | CounterType$ INST | CounterNum$ 1 | SubAbility$ CheckSolve
+T:Mode$ SpellCast | ValidCard$ Sorcery | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | IsPresent$ Card.Self+counters_GE1_SOR | PresentCompare$ EQ0 | Execute$ DecodeSor | TriggerDescription$ Condition — You cast a sorcery spell.
+SVar:DecodeSor:DB$ PutCounter | Defined$ Self | CounterType$ SOR | CounterNum$ 1 | SubAbility$ CheckSolve
+SVar:CheckSolve:DB$ SetState | Defined$ Self | Mode$ Transform | ConditionPresent$ Card.Self+counters_GE1_INST+counters_GE1_SOR
+AlternateMode:DoubleFaced
+Oracle:When CARDNAME enters, create two 1/1 red Alien creature tokens with "This creature can't block."\nCondition—You cast an instant spell.\nCondition—You cast a sorcery spell.\n(As you complete a condition, decode it. After all are decoded, you solve the mystery and transform this.)
+
+ALTERNATE
+
+Name:Epsilon, Crash Captain
+ManaCost:no cost
+Colors:red
+Types:Legendary Creature Alien
+PT:2/2
+T:Mode$ SpellCast | ValidCard$ Instant,Sorcery | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ Whenever you cast an instant or sorcery spell, create a 1/1 red Alien creature token with "This creature can't block."
+SVar:TrigToken:DB$ Token | TokenScript$ HZN/r_1_1_alien_noblock | TokenAmount$ 1 | TokenOwner$ You
+A:AB$ CopySpellAbility | Cost$ 2 R Sac<2/Alien> | ValidTgts$ Instant.YouCtrl,Sorcery.YouCtrl | TargetType$ Spell | MayChooseTarget$ True | SpellDescription$ Copy target instant or sorcery spell you control. You may choose new targets for the copy.
+Oracle:Whenever you cast an instant or sorcery spell, create a 1/1 red Alien creature token with "This creature can't block."\n{2}{R}, Sacrifice two Aliens: Copy target instant or sorcery spell you control. You may choose new targets for the copy.

--- a/forge-gui/res/cardsfolder/HZN/rainy_night_lovers.txt
+++ b/forge-gui/res/cardsfolder/HZN/rainy_night_lovers.txt
@@ -5,7 +5,7 @@ PT:3/2
 K:Haste
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigPeek | TriggerDescription$ When CARDNAME enters, look at the top four cards of your library. You may cast a red instant or sorcery spell with mana value 1 from among them without paying its mana cost. Then put the rest on the bottom of your library in any order.
 SVar:TrigPeek:DB$ PeekAndReveal | Defined$ You | PeekAmount$ 4 | NoReveal$ True | RememberPeeked$ True | SubAbility$ DBPlay
-SVar:DBPlay:DB$ Play | ValidZone$ Library | Valid$ Card.IsRemembered+red+instant,sorcery | ValidSA$ Spell.cmcEQ1 | Optional$ True | WithoutManaCost$ True | Controller$ You | Amount$ 1 | ForgetPlayed$ True | SubAbility$ DBRest
+SVar:DBPlay:DB$ Play | ValidZone$ Library | Valid$ Instant.IsRemembered+Red+cmcEQ1,Sorcery.IsRemembered+Red+cmcEQ1 | Optional$ True | WithoutManaCost$ True | Controller$ You | Amount$ 1 | ForgetPlayed$ True | SubAbility$ DBRest
 SVar:DBRest:DB$ ChangeZoneAll | ChangeType$ Card.IsRemembered | Origin$ Library | Destination$ Library | LibraryPosition$ -1 | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 Oracle:Haste\nWhen CARDNAME enters, look at the top four cards of your library. You may cast a red instant or sorcery spell with mana value 1 from among them without paying its mana cost. Then put the rest on the bottom of your library in any order.

--- a/forge-gui/res/cardsfolder/HZN/rainy_night_lovers.txt
+++ b/forge-gui/res/cardsfolder/HZN/rainy_night_lovers.txt
@@ -1,0 +1,11 @@
+Name:Rainy Night Lovers
+ManaCost:1 R R
+Types:Creature Human Artist
+PT:3/2
+K:Haste
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigPeek | TriggerDescription$ When CARDNAME enters, look at the top four cards of your library. You may cast a red instant or sorcery spell with mana value 1 from among them without paying its mana cost. Then put the rest on the bottom of your library in any order.
+SVar:TrigPeek:DB$ PeekAndReveal | Defined$ You | PeekAmount$ 4 | NoReveal$ True | RememberPeeked$ True | SubAbility$ DBPlay
+SVar:DBPlay:DB$ Play | ValidZone$ Library | Valid$ Card.IsRemembered+red+instant,sorcery | ValidSA$ Spell.cmcEQ1 | Optional$ True | WithoutManaCost$ True | Controller$ You | Amount$ 1 | ForgetPlayed$ True | SubAbility$ DBRest
+SVar:DBRest:DB$ ChangeZoneAll | ChangeType$ Card.IsRemembered | Origin$ Library | Destination$ Library | LibraryPosition$ -1 | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+Oracle:Haste\nWhen CARDNAME enters, look at the top four cards of your library. You may cast a red instant or sorcery spell with mana value 1 from among them without paying its mana cost. Then put the rest on the bottom of your library in any order.

--- a/forge-gui/res/cardsfolder/HZN/sear_flesh.txt
+++ b/forge-gui/res/cardsfolder/HZN/sear_flesh.txt
@@ -1,7 +1,7 @@
 Name:Sear Flesh
 ManaCost:R
 Types:Sorcery
-A:SP$ DealDamage | ValidTgts$ Creature,Planeswalker | TgtPrompt$ Select target creature or planeswalker | NumDmg$ 3 | SubAbility$ DBExtra | SpellDescription$ CARDNAME deals 3 damage to target creature or planeswalker. If you've cast another spell this turn, it deals 5 damage instead.
-SVar:DBExtra:DB$ DealDamage | Defined$ Targeted | NumDmg$ 2 | ConditionSVar$ X | ConditionSVarCompare$ GE2
-SVar:X:Count$ThisTurnCast_Card.YouCtrl
+A:SP$ DealDamage | ValidTgts$ Creature,Planeswalker | TgtPrompt$ Select target creature or planeswalker | NumDmg$ X | SpellDescription$ CARDNAME deals 3 damage to target creature or planeswalker. If you've cast another spell this turn, it deals 5 damage instead.
+SVar:Y:Count$ThisTurnCast_Card.YouCtrl
+SVar:X:Count$Compare Y GE2.5.3
 Oracle:Sear Flesh deals 3 damage to target creature or planeswalker. If you've cast another spell this turn, it deals 5 damage instead.

--- a/forge-gui/res/cardsfolder/HZN/sear_flesh.txt
+++ b/forge-gui/res/cardsfolder/HZN/sear_flesh.txt
@@ -1,0 +1,7 @@
+Name:Sear Flesh
+ManaCost:R
+Types:Sorcery
+A:SP$ DealDamage | ValidTgts$ Creature,Planeswalker | TgtPrompt$ Select target creature or planeswalker | NumDmg$ 3 | SubAbility$ DBExtra | SpellDescription$ CARDNAME deals 3 damage to target creature or planeswalker. If you've cast another spell this turn, it deals 5 damage instead.
+SVar:DBExtra:DB$ DealDamage | Defined$ Targeted | NumDmg$ 2 | ConditionSVar$ X | ConditionSVarCompare$ GE2
+SVar:X:Count$ThisTurnCast_Card.YouCtrl
+Oracle:Sear Flesh deals 3 damage to target creature or planeswalker. If you've cast another spell this turn, it deals 5 damage instead.

--- a/forge-gui/res/tokenscripts/HZN/g_8_8_elemental.txt
+++ b/forge-gui/res/tokenscripts/HZN/g_8_8_elemental.txt
@@ -1,0 +1,6 @@
+Name:Elemental Token
+ManaCost:no cost
+Colors:green
+Types:Creature Elemental
+PT:8/8
+Oracle:

--- a/forge-gui/res/tokenscripts/HZN/gu_1_1_elf.txt
+++ b/forge-gui/res/tokenscripts/HZN/gu_1_1_elf.txt
@@ -1,0 +1,6 @@
+Name:Elf Token
+ManaCost:no cost
+Colors:green,blue
+Types:Creature Elf
+PT:1/1
+Oracle:

--- a/forge-gui/res/tokenscripts/HZN/r_1_1_alien_noblock.txt
+++ b/forge-gui/res/tokenscripts/HZN/r_1_1_alien_noblock.txt
@@ -1,0 +1,7 @@
+Name:Alien Token
+ManaCost:no cost
+Colors:red
+Types:Creature Alien
+PT:1/1
+S:Mode$ CantBlock | ValidCard$ Creature.Self | Description$ This creature can't block.
+Oracle:This creature can't block.


### PR DESCRIPTION
## Summary
- script Mystery of the Crashed Craft // Epsilon, Crash Captain with decoding conditions and token generation
- add Rainy Night Lovers, Sear Flesh, Camahueto Calf, Dazzling Dreamspinner, Duskwood Revolutionary, Evaldi's Muse, and Horizon Wayfarer
- include supporting Alien, Elemental, and Elf tokens for HZN set

## Testing
- `mvn -q test` *(fails: Unresolveable build extension: Plugin org.apache.maven.wagon:wagon-ftp:3.5.3)*

------
https://chatgpt.com/codex/tasks/task_e_68946696132083209fd3f6a4c880b60d