### PR TITLE
Add HZN custom cards and tokens

### DIFF
--- a/forge-gui/res/cardsfolder/HZN/alonzo_departed_detective.txt
+++ b/forge-gui/res/cardsfolder/HZN/alonzo_departed_detective.txt
@@ -1,0 +1,11 @@
+Name:Alonzo, Departed Detective
+ManaCost:2 W B
+Types:Legendary Planeswalker Alonzo
+Loyalty:3
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Creature.YouCtrl+!token | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ Whenever a nontoken creature you control dies, create a 1/1 black Spirit creature token with flying.
+SVar:TrigToken:DB$ Token | TokenAmount$ 1 | TokenScript$ b_1_1_spirit_flying | TokenOwner$ You
+A:AB$ LoseLife | Cost$ AddCounter<1/LOYALTY> | Planeswalker$ True | Defined$ Player.Opponent | LifeAmount$ 2 | SubAbility$ DBGainLife | SpellDescription$ Each opponent loses 2 life and you gain 2 life.
+SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 2
+A:AB$ ImmediateTrigger | Cost$ SubCounter<2/LOYALTY> | Planeswalker$ True | Execute$ TrigDestroy | UnlessCost$ Sac<1/Creature> | UnlessPayer$ You | UnlessSwitched$ True | AILogic$ BestRemoval | SpellDescription$ You may sacrifice a creature. When you do, destroy target nonland permanent.
+SVar:TrigDestroy:DB$ Destroy | ValidTgts$ Permanent.nonLand | TgtPrompt$ Select target nonland permanent
+Oracle:Whenever a nontoken creature you control dies, create a 1/1 black Spirit creature token with flying.\n[+1]: Each opponent loses 2 life and you gain 2 life.\n[−2]: You may sacrifice a creature. When you do, destroy target nonland permanent.

--- a/forge-gui/res/cardsfolder/HZN/animara_last_of_the_fell.txt
+++ b/forge-gui/res/cardsfolder/HZN/animara_last_of_the_fell.txt
@@ -1,0 +1,11 @@
+Name:Animara, Last of the Fell
+ManaCost:1 R W B
+Types:Legendary Artifact Creature Vampire
+PT:3/2
+K:First Strike
+K:Haste
+T:Mode$ Phase | Phase$ End of Turn | CheckSVar$ LifeLostAny | SVarCompare$ GE1 | TriggerZones$ Battlefield | Execute$ TrigPutCounter | TriggerDescription$ At the beginning of each end step, if a player lost life this turn, put a +1/+1 counter on CARDNAME.
+SVar:TrigPutCounter:DB$ PutCounter | Defined$ Self | CounterType$ P1P1 | CounterNum$ 1
+SVar:LifeLostAny:PlayerCountPlayers$LifeLostThisTurn
+DeckHas:Ability$Counters
+Oracle:First strike, haste\nAt the beginning of each end step, if a player lost life this turn, put a +1/+1 counter on Animara, Last of the Fell.

--- a/forge-gui/res/cardsfolder/HZN/bvala_queen_of_the_swarm.txt
+++ b/forge-gui/res/cardsfolder/HZN/bvala_queen_of_the_swarm.txt
@@ -1,0 +1,8 @@
+Name:Bvala, Queen of the Swarm
+ManaCost:4 G W
+Types:Legendary Planeswalker Bvala
+Loyalty:4
+A:AB$ Token | Cost$ AddCounter<1/LOYALTY> | Planeswalker$ True | TokenAmount$ 1 | TokenScript$ swarm | TokenOwner$ You | SpellDescription$ Create a green enchantment token named Swarm with "At the beginning of your end step, create a 1/1 green Insect creature token."
+A:AB$ Token | Cost$ SubCounter<2/LOYALTY> | Planeswalker$ True | TokenAmount$ 1 | TokenScript$ survive | TokenOwner$ You | SpellDescription$ Create a green enchantment token named Survive with "Whenever a creature you control dies, you gain life equal to its power."
+A:AB$ Token | Cost$ SubCounter<4/LOYALTY> | Planeswalker$ True | Ultimate$ True | TokenAmount$ 1 | TokenScript$ scrounge | TokenOwner$ You | SpellDescription$ Create a green enchantment token named Scrounge with "Whenever a creature you control enters, draw a card."
+Oracle:[+1]: Create a green enchantment token named Swarm with "At the beginning of your end step, create a 1/1 green Insect creature token."\n[−2]: Create a green enchantment token named Survive with "Whenever a creature you control dies, you gain life equal to its power."\n[−4]: Create a green enchantment token named Scrounge with "Whenever a creature you control enters, draw a card."

--- a/forge-gui/res/cardsfolder/HZN/channel_the_song.txt
+++ b/forge-gui/res/cardsfolder/HZN/channel_the_song.txt
@@ -1,0 +1,6 @@
+Name:Channel the Song
+ManaCost:1 W U
+Types:Enchantment
+T:Mode$ SpellCast | ValidCard$ Card.nonCreature | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | IsPresent$ Creature.YouCtrl | PresentCompare$ EQ1 | Execute$ TrigCopy | TriggerDescription$ Whenever you cast a noncreature spell, if you control exactly one creature, copy that spell. You may choose new targets for the copies. (If it's a permanent, it resolves as a token.)
+SVar:TrigCopy:DB$ CopySpellAbility | Defined$ TriggeredSpellAbility | MayChooseTarget$ True
+Oracle:Whenever you cast a noncreature spell, if you control exactly one creature, copy that spell. You may choose new targets for the copies. (If it's a permanent, it resolves as a token.)

--- a/forge-gui/res/cardsfolder/HZN/iroshi_blade_of_the_old_ways.txt
+++ b/forge-gui/res/cardsfolder/HZN/iroshi_blade_of_the_old_ways.txt
@@ -1,0 +1,14 @@
+Name:Iroshi, Blade of the Old Ways
+ManaCost:2 G G
+Types:Legendary Planeswalker Iroshi
+Loyalty:3
+K:Flash
+S:Mode$ CastWithFlash | ValidCard$ Card.Self+ThisTurnEntered | ValidSA$ Activated.Loyalty | Caster$ You | Description$ As long as CARDNAME entered this turn, you may activate their loyalty abilities any time you could cast an instant.
+A:AB$ ChangeZone | Cost$ AddCounter<1/LOYALTY> | Planeswalker$ True | Origin$ Battlefield | Destination$ Hand | ValidTgts$ Creature.YouCtrl | TargetMin$ 0 | TargetMax$ 1 | TgtPrompt$ Select a creature you control to return | RememberChanged$ True | SubAbility$ DBDraw | SpellDescription$ You may return a creature you control to its owner's hand. If you do, draw a card.
+SVar:DBDraw:DB$ Draw | Defined$ You | NumCards$ 1 | ConditionDefined$ Remembered | ConditionPresent$ Card | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+A:AB$ Token | Cost$ SubCounter<1/LOYALTY> | Planeswalker$ True | TokenAmount$ 1 | TokenScript$ g_2_2_ninja | TokenOwner$ You | SpellDescription$ Create a 2/2 green Ninja creature token.
+A:AB$ Pump | Cost$ SubCounter<2/LOYALTY> | Planeswalker$ True | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | SubAbility$ SoulsDamage | SpellDescription$ Target creature you control deals damage equal to its power to target creature or planeswalker.
+SVar:SoulsDamage:DB$ DealDamage | ValidTgts$ Creature,Planeswalker | AILogic$ PowerDmg | TgtPrompt$ Select target creature or planeswalker | NumDmg$ X | DamageSource$ ParentTarget
+SVar:X:ParentTargeted$CardPower
+Oracle:Flash\nAs long as Iroshi, Blade of the Old Ways entered this turn, you may activate their loyalty abilities any time you could cast an instant.\n[+1]: You may return a creature you control to its owner's hand. If you do, draw a card.\n[−1]: Create a 2/2 green Ninja creature token.\n[−2]: Target creature you control deals damage equal to its power to target creature or planeswalker.

--- a/forge-gui/res/cardsfolder/HZN/lorilyf_home_tree.txt
+++ b/forge-gui/res/cardsfolder/HZN/lorilyf_home_tree.txt
@@ -1,0 +1,12 @@
+Name:Lorilyf, Home-Tree
+ManaCost:G
+Types:Legendary Enchantment Realm
+T:Mode$ SpellCast | ValidCard$ Card.Elf | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigDraw | CheckSVar$ RealmCounters | SVarCompare$ GE3 | TriggerDescription$ Whenever you cast an Elf spell, draw a card.
+A:AB$ Effect | Cost$ G | SorcerySpeed$ True | GameActivationLimit$ 1 | StaticAbilities$ Exploration | SubAbility$ DBPutCounter | SpellDescription$ You may play an additional land this turn.
+SVar:Exploration:Mode$ Continuous | Affected$ You | AdjustLandPlays$ 1 | Description$ You may play an additional land this turn.
+A:AB$ ChangeZone | Cost$ 1 G | SorcerySpeed$ True | GameActivationLimit$ 1 | Origin$ Library | Destination$ Hand | ChangeType$ Land.Forest+Basic | ChangeNum$ 1 | Reveal$ True | Shuffle$ True | SubAbility$ DBPutCounter | SpellDescription$ Search your library for a basic Forest card, reveal it, put it into your hand, then shuffle.
+A:AB$ ChangeZone | Cost$ 2 G | SorcerySpeed$ True | GameActivationLimit$ 1 | Origin$ Library | Destination$ Hand | ChangeType$ Card.Elf | ChangeNum$ 1 | Reveal$ True | Shuffle$ True | SubAbility$ DBPutCounter | SpellDescription$ Search your library for an Elf card, reveal it, put it into your hand, then shuffle.
+SVar:DBPutCounter:DB$ PutCounter | Defined$ Self | CounterType$ QUEST | CounterNum$ 1
+SVar:TrigDraw:DB$ Draw | Defined$ You | NumCards$ 1
+SVar:RealmCounters:Count$CardCounters.QUEST
+Oracle:(Activate each ability only once as a sorcery. You gain the realm's favor after activating them all.)\n{G}: You may play an additional land this turn.\n{1}{G}: Search your library for a basic Forest card, reveal it, put it into your hand, then shuffle.\n{2}{G}: Search your library for an Elf card, reveal it, put it into your hand, then shuffle.\nFavor — Whenever you cast an Elf spell, draw a card.

--- a/forge-gui/res/cardsfolder/HZN/vasille_rioters.txt
+++ b/forge-gui/res/cardsfolder/HZN/vasille_rioters.txt
@@ -1,0 +1,9 @@
+Name:Vasille Rioters
+ManaCost:1 G
+Types:Creature Elf Citizen
+PT:1/2
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigConjure | TriggerDescription$ When CARDNAME enters, conjure three cards named Vasille Rioters and shuffle them into your library, then you get a riot counter.
+SVar:TrigConjure:DB$ MakeCard | Conjure$ True | Name$ Vasille Rioters | Zone$ Library | Amount$ 3 | SubAbility$ DBPutCounter
+SVar:DBPutCounter:DB$ PutCounter | Defined$ You | CounterType$ Riot | CounterNum$ 1
+S:Mode$ Continuous | Affected$ Card.Self | AddPower$ X | AddToughness$ X | SVar:X:Count$YourCountersRiot | Description$ CARDNAME gets +1/+1 for each riot counter you have.
+Oracle:When Vasille Rioters enters, conjure three cards named Vasille Rioters and shuffle them into your library, then you get a riot counter.\nVasille Rioters gets +1/+1 for each riot counter you have.

--- a/forge-gui/res/tokenscripts/HZN/b_1_1_spirit_flying.txt
+++ b/forge-gui/res/tokenscripts/HZN/b_1_1_spirit_flying.txt
@@ -1,0 +1,7 @@
+Name:Spirit Token
+ManaCost:no cost
+Colors:black
+Types:Creature Spirit
+PT:1/1
+K:Flying
+Oracle:Flying

--- a/forge-gui/res/tokenscripts/HZN/g_2_2_ninja.txt
+++ b/forge-gui/res/tokenscripts/HZN/g_2_2_ninja.txt
@@ -1,0 +1,6 @@
+Name:Ninja Token
+ManaCost:no cost
+Colors:green
+Types:Creature Ninja
+PT:2/2
+Oracle:

--- a/forge-gui/res/tokenscripts/HZN/scrounge.txt
+++ b/forge-gui/res/tokenscripts/HZN/scrounge.txt
@@ -1,0 +1,7 @@
+Name:Scrounge
+ManaCost:no cost
+Colors:green
+Types:Enchantment
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Creature.YouCtrl | TriggerZones$ Battlefield | Execute$ TrigDraw | TriggerDescription$ Whenever a creature you control enters, draw a card.
+SVar:TrigDraw:DB$ Draw | Defined$ You | NumCards$ 1
+Oracle:Whenever a creature you control enters, draw a card.

--- a/forge-gui/res/tokenscripts/HZN/survive.txt
+++ b/forge-gui/res/tokenscripts/HZN/survive.txt
@@ -1,0 +1,8 @@
+Name:Survive
+ManaCost:no cost
+Colors:green
+Types:Enchantment
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Creature.YouCtrl | TriggerZones$ Battlefield | Execute$ TrigGain | TriggerDescription$ Whenever a creature you control dies, you gain life equal to its power.
+SVar:TrigGain:DB$ GainLife | Defined$ You | LifeAmount$ X
+SVar:X:TriggeredCard$CardPower
+Oracle:Whenever a creature you control dies, you gain life equal to its power.

--- a/forge-gui/res/tokenscripts/HZN/swarm.txt
+++ b/forge-gui/res/tokenscripts/HZN/swarm.txt
@@ -1,0 +1,7 @@
+Name:Swarm
+ManaCost:no cost
+Colors:green
+Types:Enchantment
+T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ At the beginning of your end step, create a 1/1 green Insect creature token.
+SVar:TrigToken:DB$ Token | TokenAmount$ 1 | TokenScript$ g_1_1_insect | TokenOwner$ You
+Oracle:At the beginning of your end step, create a 1/1 green Insect creature token.


### PR DESCRIPTION
## Summary
- script Iroshi, Alonzo, Bvala and other HZN cards
- add Swarm/Survive/Scrounge enchantment tokens and Ninja & Spirit creature tokens
- handle realm favor and riot counters interactions

## Testing
- `mvn -q -pl forge-gui -am test` *(fails: Unresolveable build extension org.apache.maven.wagon:wagon-ftp:3.5.3)*

------
https://chatgpt.com/codex/tasks/task_e_68946db6f1688320b75516d7df0c840b