### PR TITLE
Add HZN custom cards and tokens

### DIFF
--- a/forge-gui/res/cardsfolder/HZN/alonzo_departed_detective.txt
+++ b/forge-gui/res/cardsfolder/HZN/alonzo_departed_detective.txt
@@ -2,7 +2,7 @@ Name:Alonzo, Departed Detective
 ManaCost:2 W B
 Types:Legendary Planeswalker Alonzo
 Loyalty:3
-T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Creature.nontoken+YouCtrl | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ Whenever a nontoken creature you control dies, create a 1/1 black Spirit creature token with flying.
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Creature.!token+YouCtrl | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ Whenever a nontoken creature you control dies, create a 1/1 black Spirit creature token with flying.
 SVar:TrigToken:DB$ Token | TokenAmount$ 1 | TokenScript$ b_1_1_spirit_flying | TokenOwner$ You
 A:AB$ LoseLife | Cost$ AddCounter<1/LOYALTY> | Planeswalker$ True | Defined$ Opponent | LifeAmount$ 2 | SubAbility$ DBGainLife | SpellDescription$ Each opponent loses 2 life and you gain 2 life.
 SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 2

--- a/forge-gui/res/cardsfolder/HZN/alonzo_departed_detective.txt
+++ b/forge-gui/res/cardsfolder/HZN/alonzo_departed_detective.txt
@@ -1,0 +1,10 @@
+Name:Alonzo, Departed Detective
+ManaCost:2 W B
+Types:Legendary Planeswalker Alonzo
+Loyalty:3
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Creature.nontoken+YouCtrl | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ Whenever a nontoken creature you control dies, create a 1/1 black Spirit creature token with flying.
+SVar:TrigToken:DB$ Token | TokenAmount$ 1 | TokenScript$ b_1_1_spirit_flying | TokenOwner$ You
+A:AB$ LoseLife | Cost$ AddCounter<1/LOYALTY> | Planeswalker$ True | Defined$ Opponent | LifeAmount$ 2 | SubAbility$ DBGainLife | SpellDescription$ Each opponent loses 2 life and you gain 2 life.
+SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 2
+A:AB$ Destroy | Cost$ SubCounter<2/LOYALTY> | Planeswalker$ True | ValidTgts$ Permanent.nonLand | TgtPrompt$ Select target nonland permanent | UnlessCost$ Sac<1/Creature> | UnlessSwitched$ True | UnlessPayer$ You | SpellDescription$ You may sacrifice a creature. When you do, destroy target nonland permanent.
+Oracle:Whenever a nontoken creature you control dies, create a 1/1 black Spirit creature token with flying.\n[+1]: Each opponent loses 2 life and you gain 2 life.\n[-2]: You may sacrifice a creature. When you do, destroy target nonland permanent.

--- a/forge-gui/res/cardsfolder/HZN/animara_last_of_the_fell.txt
+++ b/forge-gui/res/cardsfolder/HZN/animara_last_of_the_fell.txt
@@ -1,0 +1,10 @@
+Name:Animara, Last of the Fell
+ManaCost:1 R W B
+Types:Legendary Artifact Creature Vampire
+PT:3/2
+K:First Strike
+K:Haste
+T:Mode$ Phase | Phase$ EndStep | ValidPlayer$ Player | CheckSVar$ X | SVarCompare$ GE1 | TriggerZones$ Battlefield | Execute$ TrigCounter | TriggerDescription$ At the beginning of each end step, if a player lost life this turn, put a +1/+1 counter on CARDNAME.
+SVar:TrigCounter:DB$ PutCounter | Defined$ Self | CounterType$ P1P1 | CounterNum$ 1
+SVar:X:PlayerCountPlayers$LifeLostThisTurn
+Oracle:First strike, haste\nAt the beginning of each end step, if a player lost life this turn, put a +1/+1 counter on Animara, Last of the Fell.

--- a/forge-gui/res/cardsfolder/HZN/animara_last_of_the_fell.txt
+++ b/forge-gui/res/cardsfolder/HZN/animara_last_of_the_fell.txt
@@ -4,7 +4,7 @@ Types:Legendary Artifact Creature Vampire
 PT:3/2
 K:First Strike
 K:Haste
-T:Mode$ Phase | Phase$ EndStep | ValidPlayer$ Player | CheckSVar$ X | SVarCompare$ GE1 | TriggerZones$ Battlefield | Execute$ TrigCounter | TriggerDescription$ At the beginning of each end step, if a player lost life this turn, put a +1/+1 counter on CARDNAME.
+T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ Player | CheckSVar$ X | SVarCompare$ GE1 | TriggerZones$ Battlefield | Execute$ TrigCounter | TriggerDescription$ At the beginning of each end step, if a player lost life this turn, put a +1/+1 counter on CARDNAME.
 SVar:TrigCounter:DB$ PutCounter | Defined$ Self | CounterType$ P1P1 | CounterNum$ 1
 SVar:X:PlayerCountPlayers$LifeLostThisTurn
 Oracle:First strike, haste\nAt the beginning of each end step, if a player lost life this turn, put a +1/+1 counter on Animara, Last of the Fell.

--- a/forge-gui/res/cardsfolder/HZN/bvala_queen_of_the_swarm.txt
+++ b/forge-gui/res/cardsfolder/HZN/bvala_queen_of_the_swarm.txt
@@ -1,0 +1,8 @@
+Name:Bvala, Queen of the Swarm
+ManaCost:4 G W
+Types:Legendary Planeswalker Bvala
+Loyalty:4
+A:AB$ Token | Cost$ AddCounter<1/LOYALTY> | Planeswalker$ True | TokenAmount$ 1 | TokenScript$ hzn_swarm | TokenOwner$ You | SpellDescription$ Create a green enchantment token named Swarm with "At the beginning of your end step, create a 1/1 green Insect creature token."
+A:AB$ Token | Cost$ SubCounter<2/LOYALTY> | Planeswalker$ True | TokenAmount$ 1 | TokenScript$ hzn_survive | TokenOwner$ You | SpellDescription$ Create a green enchantment token named Survive with "Whenever a creature you control dies, you gain life equal to its power."
+A:AB$ Token | Cost$ SubCounter<4/LOYALTY> | Planeswalker$ True | TokenAmount$ 1 | TokenScript$ hzn_scrounge | TokenOwner$ You | SpellDescription$ Create a green enchantment token named Scrounge with "Whenever a creature you control enters, draw a card."
+Oracle:[+1]: Create a green enchantment token named Swarm with "At the beginning of your end step, create a 1/1 green Insect creature token."\n[-2]: Create a green enchantment token named Survive with "Whenever a creature you control dies, you gain life equal to its power."\n[-4]: Create a green enchantment token named Scrounge with "Whenever a creature you control enters, draw a card."

--- a/forge-gui/res/cardsfolder/HZN/channel_the_song.txt
+++ b/forge-gui/res/cardsfolder/HZN/channel_the_song.txt
@@ -1,0 +1,7 @@
+Name:Channel the Song
+ManaCost:1 W U
+Types:Enchantment
+T:Mode$ SpellCast | ValidCard$ Card.nonCreature | ValidActivatingPlayer$ You | CheckSVar$ CreatCount | SVarCompare$ EQ1 | Execute$ TrigCopy | TriggerZones$ Battlefield | TriggerDescription$ Whenever you cast a noncreature spell, if you control exactly one creature, copy that spell. You may choose new targets for the copy. (If it's a permanent, it resolves as a token.)
+SVar:CreatCount:Count$Valid Creature.YouCtrl
+SVar:TrigCopy:DB$ CopySpellAbility | Defined$ TriggeredSpellAbility | MayChooseTarget$ True
+Oracle:Whenever you cast a noncreature spell, if you control exactly one creature, copy that spell. You may choose new targets for the copy. (If it's a permanent, it resolves as a token.)

--- a/forge-gui/res/cardsfolder/HZN/iroshi_blade_of_the_old_ways.txt
+++ b/forge-gui/res/cardsfolder/HZN/iroshi_blade_of_the_old_ways.txt
@@ -1,0 +1,12 @@
+Name:Iroshi, Blade of the Old Ways
+ManaCost:2 G G
+Types:Legendary Planeswalker Iroshi
+K:Flash
+Loyalty:3
+S:Mode$ CastWithFlash | ValidCard$ Card.Self | ValidSA$ Activated.Loyalty | Caster$ You | IsPresent$ Card.Self+ThisTurnEntered | Description$ As long as CARDNAME entered this turn, you may activate its loyalty abilities any time you could cast an instant.
+A:AB$ Draw | Cost$ AddCounter<1/LOYALTY> | Planeswalker$ True | Defined$ You | NumCards$ 1 | UnlessCost$ Return<1/Creature.YouCtrl> | UnlessSwitched$ True | UnlessPayer$ You | SpellDescription$ You may return a creature you control to its owner's hand. If you do, draw a card.
+A:AB$ Token | Cost$ SubCounter<1/LOYALTY> | Planeswalker$ True | TokenAmount$ 1 | TokenScript$ g_2_2_ninja | TokenOwner$ You | SpellDescription$ Create a 2/2 green Ninja creature token.
+A:AB$ Pump | Cost$ SubCounter<2/LOYALTY> | Planeswalker$ True | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | AILogic$ PowerDmg | SubAbility$ DBDamage | SpellDescription$ Target creature you control deals damage equal to its power to target creature or planeswalker.
+SVar:DBDamage:DB$ DealDamage | ValidTgts$ Creature,Planeswalker | TgtPrompt$ Select target creature or planeswalker | NumDmg$ X | DamageSource$ ParentTarget
+SVar:X:ParentTargeted$CardPower
+Oracle:Flash\nAs long as Iroshi, Blade of the Old Ways entered this turn, you may activate its loyalty abilities any time you could cast an instant.\n[+1]: You may return a creature you control to its owner's hand. If you do, draw a card.\n[-1]: Create a 2/2 green Ninja creature token.\n[-2]: Target creature you control deals damage equal to its power to target creature or planeswalker.

--- a/forge-gui/res/cardsfolder/HZN/lorilyf_home_tree.txt
+++ b/forge-gui/res/cardsfolder/HZN/lorilyf_home_tree.txt
@@ -9,11 +9,11 @@ SVar:Mark2:DB$ PutCounter | Defined$ Self | CounterType$ R2 | CounterNum$ 1 | Su
 A:AB$ ChangeZone | Cost$ 2 G | SorcerySpeed$ True | ActivationLimit$ 1 | CheckSVar$ used3 | SVarCompare$ EQ0 | Origin$ Library | Destination$ Hand | ChangeType$ Creature.Elf | ChangeNum$ 1 | Reveal$ True | Shuffle$ True | SubAbility$ Mark3 | SpellDescription$ Search your library for an Elf card, reveal it, put it into your hand, then shuffle.
 SVar:Mark3:DB$ PutCounter | Defined$ Self | CounterType$ R3 | CounterNum$ 1 | SubAbility$ AddRealm
 SVar:AddRealm:DB$ PutCounter | Defined$ Self | CounterType$ QUEST | CounterNum$ 1
-S:Mode$ Continuous | Affected$ Card.Self | CheckSVar$ RealmCount | SVarCompare$ GE3 | AddAbility$ FavorTrig | Description$ Favor — Whenever you cast an Elf spell, draw a card.
-SVar:RealmCount:Count$SelfCounters.QUEST
-SVar:used1:Count$SelfCounters.R1
-SVar:used2:Count$SelfCounters.R2
-SVar:used3:Count$SelfCounters.R3
-SVar:FavorTrig:Trigger$ SpellCast | ValidCard$ Elf | ValidActivatingPlayer$ You | Execute$ DBDraw | TriggerDescription$ Whenever you cast an Elf spell, draw a card.
+S:Mode$ Continuous | Affected$ Card.Self | CheckSVar$ RealmCount | SVarCompare$ GE3 | AddTrigger$ FavorTrig | Description$ Favor — Whenever you cast an Elf spell, draw a card.
+SVar:RealmCount:Count$CardCounters.QUEST
+SVar:used1:Count$CardCounters.R1
+SVar:used2:Count$CardCounters.R2
+SVar:used3:Count$CardCounters.R3
+SVar:FavorTrig:Mode$ SpellCast | ValidCard$ Elf | ValidActivatingPlayer$ You | Execute$ DBDraw | TriggerDescription$ Whenever you cast an Elf spell, draw a card.
 SVar:DBDraw:DB$ Draw | Defined$ You | NumCards$ 1
 Oracle:(Activate each ability only once as a sorcery. You gain the realm's favor after activating them all.)\n{G}: You may play an additional land this turn.\n{1}{G}: Search your library for a basic Forest card, reveal it, put it into your hand, then shuffle.\n{2}{G}: Search your library for an Elf card, reveal it, put it into your hand, then shuffle.\nFavor — Whenever you cast an Elf spell, draw a card.

--- a/forge-gui/res/cardsfolder/HZN/lorilyf_home_tree.txt
+++ b/forge-gui/res/cardsfolder/HZN/lorilyf_home_tree.txt
@@ -1,0 +1,19 @@
+Name:Lorilyf, Home-Tree
+ManaCost:G
+Types:Legendary Enchantment Realm
+A:AB$ Effect | Cost$ G | SorcerySpeed$ True | ActivationLimit$ 1 | CheckSVar$ used1 | SVarCompare$ EQ0 | StaticAbilities$ Exploration | SubAbility$ Mark1 | SpellDescription$ You may play an additional land this turn.
+SVar:Exploration:Mode$ Continuous | Affected$ You | AdjustLandPlays$ 1 | Description$ You may play an additional land this turn.
+SVar:Mark1:DB$ PutCounter | Defined$ Self | CounterType$ R1 | CounterNum$ 1 | SubAbility$ AddRealm
+A:AB$ ChangeZone | Cost$ 1 G | SorcerySpeed$ True | ActivationLimit$ 1 | CheckSVar$ used2 | SVarCompare$ EQ0 | Origin$ Library | Destination$ Hand | ChangeType$ Land.Basic+Forest | ChangeNum$ 1 | Reveal$ True | Shuffle$ True | SubAbility$ Mark2 | SpellDescription$ Search your library for a basic Forest card, reveal it, put it into your hand, then shuffle.
+SVar:Mark2:DB$ PutCounter | Defined$ Self | CounterType$ R2 | CounterNum$ 1 | SubAbility$ AddRealm
+A:AB$ ChangeZone | Cost$ 2 G | SorcerySpeed$ True | ActivationLimit$ 1 | CheckSVar$ used3 | SVarCompare$ EQ0 | Origin$ Library | Destination$ Hand | ChangeType$ Creature.Elf | ChangeNum$ 1 | Reveal$ True | Shuffle$ True | SubAbility$ Mark3 | SpellDescription$ Search your library for an Elf card, reveal it, put it into your hand, then shuffle.
+SVar:Mark3:DB$ PutCounter | Defined$ Self | CounterType$ R3 | CounterNum$ 1 | SubAbility$ AddRealm
+SVar:AddRealm:DB$ PutCounter | Defined$ Self | CounterType$ QUEST | CounterNum$ 1
+S:Mode$ Continuous | Affected$ Card.Self | CheckSVar$ RealmCount | SVarCompare$ GE3 | AddAbility$ FavorTrig | Description$ Favor — Whenever you cast an Elf spell, draw a card.
+SVar:RealmCount:Count$SelfCounters.QUEST
+SVar:used1:Count$SelfCounters.R1
+SVar:used2:Count$SelfCounters.R2
+SVar:used3:Count$SelfCounters.R3
+SVar:FavorTrig:Trigger$ SpellCast | ValidCard$ Elf | ValidActivatingPlayer$ You | Execute$ DBDraw | TriggerDescription$ Whenever you cast an Elf spell, draw a card.
+SVar:DBDraw:DB$ Draw | Defined$ You | NumCards$ 1
+Oracle:(Activate each ability only once as a sorcery. You gain the realm's favor after activating them all.)\n{G}: You may play an additional land this turn.\n{1}{G}: Search your library for a basic Forest card, reveal it, put it into your hand, then shuffle.\n{2}{G}: Search your library for an Elf card, reveal it, put it into your hand, then shuffle.\nFavor — Whenever you cast an Elf spell, draw a card.

--- a/forge-gui/res/cardsfolder/HZN/vasille_rioters.txt
+++ b/forge-gui/res/cardsfolder/HZN/vasille_rioters.txt
@@ -1,0 +1,10 @@
+Name:Vasille Rioters
+ManaCost:1 G
+Types:Creature Elf Citizen
+PT:1/2
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigConjure | TriggerDescription$ When CARDNAME enters, conjure three cards named Vasille Rioters into your library, then you get a riot counter.
+SVar:TrigConjure:DB$ MakeCard | Conjure$ True | Name$ Vasille Rioters | Zone$ Library | Amount$ 3 | SubAbility$ DBRiot
+SVar:DBRiot:DB$ PutCounter | Defined$ You | CounterType$ Riot | CounterNum$ 1
+S:Mode$ Continuous | Affected$ Card.Self | AddPower$ X | AddToughness$ X | Description$ CARDNAME gets +1/+1 for each riot counter you have.
+SVar:X:Count$YourCountersRiot
+Oracle:When Vasille Rioters enters, conjure three cards named Vasille Rioters and shuffle them into your library, then you get a riot counter.\nVasille Rioters gets +1/+1 for each riot counter you have.

--- a/forge-gui/res/tokenscripts/HZN/b_1_1_spirit_flying.txt
+++ b/forge-gui/res/tokenscripts/HZN/b_1_1_spirit_flying.txt
@@ -1,0 +1,7 @@
+Name:Spirit Token
+ManaCost:no cost
+Colors:black
+Types:Creature Spirit
+PT:1/1
+K:Flying
+Oracle:Flying

--- a/forge-gui/res/tokenscripts/HZN/g_2_2_ninja.txt
+++ b/forge-gui/res/tokenscripts/HZN/g_2_2_ninja.txt
@@ -1,0 +1,4 @@
+Name:Ninja
+Colors:G
+Types:Creature Ninja
+PT:2/2

--- a/forge-gui/res/tokenscripts/HZN/hzn_scrounge.txt
+++ b/forge-gui/res/tokenscripts/HZN/hzn_scrounge.txt
@@ -1,0 +1,5 @@
+Name:Scrounge
+Colors:G
+Types:Enchantment
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Creature.YouCtrl | TriggerZones$ Battlefield | Execute$ TrigDraw | TriggerDescription$ Whenever a creature you control enters, draw a card.
+SVar:TrigDraw:DB$ Draw | Defined$ You | NumCards$ 1

--- a/forge-gui/res/tokenscripts/HZN/hzn_survive.txt
+++ b/forge-gui/res/tokenscripts/HZN/hzn_survive.txt
@@ -1,0 +1,6 @@
+Name:Survive
+Colors:G
+Types:Enchantment
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Creature.YouCtrl | TriggerZones$ Battlefield | Execute$ TrigGain | TriggerDescription$ Whenever a creature you control dies, you gain life equal to its power.
+SVar:TrigGain:DB$ GainLife | Defined$ You | LifeAmount$ X
+SVar:X:TriggeredCard$CardPower

--- a/forge-gui/res/tokenscripts/HZN/hzn_swarm.txt
+++ b/forge-gui/res/tokenscripts/HZN/hzn_swarm.txt
@@ -1,0 +1,5 @@
+Name:Swarm
+Colors:G
+Types:Enchantment
+T:Mode$ Phase | Phase$ EndStep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ At the beginning of your end step, create a 1/1 green Insect creature token.
+SVar:TrigToken:DB$ Token | TokenAmount$ 1 | TokenScript$ g_1_1_insect | TokenOwner$ You

--- a/forge-gui/res/tokenscripts/HZN/hzn_swarm.txt
+++ b/forge-gui/res/tokenscripts/HZN/hzn_swarm.txt
@@ -1,5 +1,5 @@
 Name:Swarm
 Colors:G
 Types:Enchantment
-T:Mode$ Phase | Phase$ EndStep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ At the beginning of your end step, create a 1/1 green Insect creature token.
+T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ At the beginning of your end step, create a 1/1 green Insect creature token.
 SVar:TrigToken:DB$ Token | TokenAmount$ 1 | TokenScript$ g_1_1_insect | TokenOwner$ You


### PR DESCRIPTION
## Summary
- script Iroshi, Blade of the Old Ways with flash and instant-speed loyalty activations
- add Lorilyf, Home-Tree realm enchantment with once-per-game abilities and favor bonus
- add Vasille Rioters, Alonzo, Animara, Bvala planeswalker, and Channel the Song with supporting tokens

## Testing
- `mvn -q -pl forge-gui -am test` *(fails: Unresolveable build extension org.apache.maven.wagon:wagon-ftp:3.5.3)*

------
https://chatgpt.com/codex/tasks/task_e_68946db6f1688320b75516d7df0c840b