### PR TITLE
Add custom HZN card scripts and token

### DIFF
--- a/forge-gui/res/cardsfolder/HZN/glimpse_in_the_static.txt
+++ b/forge-gui/res/cardsfolder/HZN/glimpse_in_the_static.txt
@@ -1,0 +1,11 @@
+Name:Glimpse in the Static
+ManaCost:1 W U
+Types:Enchantment
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigExile | TriggerDescription$ When CARDNAME enters, exile target creature an opponent controls until CARDNAME leaves the battlefield.
+SVar:TrigExile:DB$ ChangeZone | Origin$ Battlefield | Destination$ Exile | ValidTgts$ Creature.OppCtrl | TgtPrompt$ Select target creature an opponent controls | Imprint$ True | Duration$ UntilHostLeavesPlay
+T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | Execute$ TrigCopy | TriggerDescription$ At the beginning of your upkeep, target player creates a token that's a copy of the exiled card, then exiles that token.
+SVar:TrigCopy:DB$ CopyPermanent | Defined$ Imprinted | Controller$ Targeted | RememberTokens$ True | ValidTgts$ Player | TgtPrompt$ Select target player | SubAbility$ DBExileToken
+SVar:DBExileToken:DB$ ChangeZone | Origin$ Battlefield | Destination$ Exile | Defined$ Remembered | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:PlayMain1:TRUE
+Oracle:When Glimpse in the Static enters, exile target creature an opponent controls until Glimpse in the Static leaves the battlefield.\nAt the beginning of your upkeep, target player creates a token that's a copy of the exiled card, then exiles that token.

--- a/forge-gui/res/cardsfolder/HZN/griamoor_deathless_warrior.txt
+++ b/forge-gui/res/cardsfolder/HZN/griamoor_deathless_warrior.txt
@@ -1,0 +1,10 @@
+Name:Griamoor, Deathless Warrior
+ManaCost:2 R W
+Types:Legendary Planeswalker Griamoor
+Loyalty:5
+A:AB$ Effect | Cost$ AddCounter<2/LOYALTY> | Planeswalker$ True | ValidTgts$ Creature | TargetMin$ 0 | TargetMax$ 1 | TgtPrompt$ Select target creature | RememberObjects$ Targeted | StaticAbilities$ MustAttackGriamoor | Duration$ UntilYourNextTurn | SpellDescription$ Up to one target creature must attack CARDNAME during its controller's next turn if able.
+SVar:MustAttackGriamoor:Mode$ MustAttack | ValidCreature$ Card.IsRemembered | MustAttack$ CardSource | Description$ This creature attacks CARDNAME during its controller's next turn if able.
+A:AB$ Animate | Cost$ AddCounter<0/LOYALTY> | Defined$ Self | Power$ X | Toughness$ X | Keywords$ Indestructible | Types$ Creature,Human,Soldier | Planeswalker$ True | SpellDescription$ Until end of turn, CARDNAME becomes a Human Soldier creature with power and toughness each equal to the number of loyalty counters on him and gains indestructible. He's still a planeswalker.
+A:AB$ DealDamage | Cost$ SubCounter<2/LOYALTY> | ValidTgts$ Creature | NumDmg$ X | Planeswalker$ True | AILogic$ PowerDmg | SpellDescription$ CARDNAME deals damage equal to the number of loyalty counters on him to target creature.
+SVar:X:Count$CardCounters.LOYALTY
+Oracle:[+2]: Up to one target creature must attack Griamoor, Deathless Warrior during its controller's next turn if able.\n[0]: Until end of turn, Griamoor becomes a Human Soldier creature with power and toughness each equal to the number of loyalty counters on him and gains indestructible.\n[–2]: Griamoor deals damage equal to the number of loyalty counters on him to target creature.

--- a/forge-gui/res/cardsfolder/HZN/hop_of_life.txt
+++ b/forge-gui/res/cardsfolder/HZN/hop_of_life.txt
@@ -1,0 +1,6 @@
+Name:Hop of Life
+ManaCost:1 G U
+Types:Sorcery
+A:SP$ CopyPermanent | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | SetPower$ 2 | SetToughness$ 2 | SpellDescription$ Create a token that's a copy of target creature you control, except it has base power and toughness 2/2.
+K:Retrace
+Oracle:Create a token that's a copy of target creature you control, except it has base power and toughness 2/2.\nRetrace (You may cast this card from your graveyard by discarding a land card in addition to paying its other costs.)

--- a/forge-gui/res/cardsfolder/HZN/idyll.txt
+++ b/forge-gui/res/cardsfolder/HZN/idyll.txt
@@ -1,0 +1,9 @@
+Name:Idyll
+ManaCost:1 R G
+Types:Creature Incarnation
+PT:3/3
+S:Mode$ Continuous | Affected$ Land.nonToken+YouCtrl | EffectZone$ Battlefield | GainsAbilitiesOf$ Land.Other | Description$ Each nontoken land you control has all activated abilities of each other land on the battlefield.
+T:Mode$ LeavesBattlefield | ValidCard$ Card.Self | Execute$ TrigEffect | TriggerDescription$ When CARDNAME leaves the battlefield, until the end of your next turn, you gain "Each nontoken land you control has all activated abilities of each other land on the battlefield."
+SVar:TrigEffect:DB$ Effect | StaticAbilities$ STLands | Duration$ UntilEndOfYourNextTurn
+SVar:STLands:Mode$ Continuous | Affected$ Land.nonToken+YouCtrl | EffectZone$ Battlefield | GainsAbilitiesOf$ Land.Other | Description$ Each nontoken land you control has all activated abilities of each other land on the battlefield.
+Oracle:Each nontoken land you control has all activated abilities of each other land on the battlefield.\nWhen Idyll leaves the battlefield, until the end of your next turn, you gain "Each nontoken land you control has all activated abilities of each other land on the battlefield."

--- a/forge-gui/res/cardsfolder/HZN/pixie_procurer.txt
+++ b/forge-gui/res/cardsfolder/HZN/pixie_procurer.txt
@@ -1,0 +1,9 @@
+Name:Pixie Procurer
+ManaCost:2 G U
+Types:Creature Faerie Rogue
+PT:2/2
+K:Flash
+K:Flying
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigCopy | TriggerDescription$ When CARDNAME enters, copy target activated ability, triggered ability, or spell with mana value 2 or less. You may choose new targets for the copy. (A copy of a permanent spell becomes a token.)
+SVar:TrigCopy:DB$ CopySpellAbility | TargetType$ Activated,Triggered,Spell | ValidTgts$ Card.cmcLE2 | MayChooseTarget$ True | TgtPrompt$ Select target ability or spell with mana value 2 or less
+Oracle:Flash\nFlying\nWhen Pixie Procurer enters, copy target activated ability, triggered ability, or spell with mana value 2 or less. You may choose new targets for the copy. (A copy of a permanent spell becomes a token.)

--- a/forge-gui/res/cardsfolder/HZN/repents_champion.txt
+++ b/forge-gui/res/cardsfolder/HZN/repents_champion.txt
@@ -1,0 +1,7 @@
+Name:Repent's Champion
+ManaCost:R W
+Types:Creature Human Soldier
+PT:2/2
+K:Lifelink
+K:Prowess
+Oracle:Lifelink\nProwess

--- a/forge-gui/res/cardsfolder/HZN/ria_demian_charm.txt
+++ b/forge-gui/res/cardsfolder/HZN/ria_demian_charm.txt
@@ -1,0 +1,9 @@
+Name:Ria-Demian Charm
+ManaCost:1 B R
+Types:Instant
+A:SP$ Charm | Choices$ DestroyMono,DamageAll,DiscardAll
+SVar:DestroyMono:DB$ Destroy | ValidTgts$ Creature.Monocolored | TgtPrompt$ Select target monocolored creature | SpellDescription$ Destroy target monocolored creature.
+SVar:DamageAll:DB$ DamageAll | NumDmg$ 2 | ValidCards$ Creature | SpellDescription$ CARDNAME deals 2 damage to each creature.
+SVar:DiscardAll:DB$ Discard | Defined$ Player | NumCards$ 2 | SubAbility$ DBLoseLife | SpellDescription$ Each player discards two cards and loses 2 life.
+SVar:DBLoseLife:DB$ LoseLife | Defined$ Player | LifeAmount$ 2
+Oracle:Choose one —\n• Destroy target monocolored creature.\n• Ria-Demian Charm deals 2 damage to each creature.\n• Each player discards two cards and loses 2 life.

--- a/forge-gui/res/cardsfolder/HZN/solar_flare.txt
+++ b/forge-gui/res/cardsfolder/HZN/solar_flare.txt
@@ -1,0 +1,6 @@
+Name:Solar Flare
+ManaCost:R G
+Types:Instant
+A:SP$ DealDamage | NumDmg$ 3 | ValidTgts$ Any | SubAbility$ DBGainLife | SpellDescription$ CARDNAME deals 3 damage to any target. You gain 3 life.
+SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 3
+Oracle:Solar Flare deals 3 damage to any target. You gain 3 life.

--- a/forge-gui/res/cardsfolder/HZN/vulture_valleys.txt
+++ b/forge-gui/res/cardsfolder/HZN/vulture_valleys.txt
@@ -1,0 +1,9 @@
+Name:Vulture Valleys
+ManaCost:1 B G
+Types:Enchantment
+T:Mode$ SpellCast | ValidCard$ Card | ValidActivatingPlayer$ You | ConditionManaSpent$ C | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ Overcast — Whenever you cast a spell, if {C} was spent to cast it, create a 1/1 black Bird creature token with flying and menace.
+SVar:TrigToken:DB$ Token | TokenScript$ b_1_1_bird_flying_menace | TokenOwner$ You
+T:Mode$ DamageDoneOnce | CombatDamage$ True | ValidSource$ Creature.YouCtrl | ValidTarget$ Player | Execute$ TrigReturn | TriggerDescription$ Whenever three or more creatures you control deal combat damage to a player, return target card from your graveyard to your hand.
+SVar:TrigReturn:DB$ ChangeZone | Origin$ Graveyard | Destination$ Hand | ValidTgts$ Card | TgtPrompt$ Select target card in your graveyard | ConditionCheckSVar$ X | ConditionSVarCompare$ GE3 | SpellDescription$ Return target card from your graveyard to your hand.
+SVar:X:TriggerCount$DamageSources
+Oracle:Overcast — Whenever you cast a spell, create a 1/1 black Bird creature token with flying and menace if {C} was spent to cast it.\nWhenever three or more creatures you control deal combat damage to a player, return target card from your graveyard to your hand.

--- a/forge-gui/res/cardsfolder/HZN/warfaring_epunamun.txt
+++ b/forge-gui/res/cardsfolder/HZN/warfaring_epunamun.txt
@@ -1,0 +1,8 @@
+Name:Warfaring Epunamun
+ManaCost:B R
+Types:Creature Spirit Warrior
+PT:3/1
+T:Mode$ SpellCast | ValidCard$ Card.wasCastFromYourGraveyard | ValidActivatingPlayer$ You | Execute$ TrigCopy | TriggerZones$ Battlefield | TriggerDescription$ Whenever you cast a spell from your graveyard, you may sacrifice a creature. If you do, copy that spell. You may choose new targets for the copy.
+SVar:TrigCopy:DB$ Sacrifice | ValidTgts$ Creature.YouCtrl | Optional$ True | SubAbility$ DBCopy
+SVar:DBCopy:DB$ CopySpellAbility | Defined$ TriggeredSpellAbility | Controller$ You | MayChooseTarget$ True
+Oracle:Whenever you cast a spell from your graveyard, you may sacrifice a creature. If you do, copy that spell. You may choose new targets for the copy.

--- a/forge-gui/res/tokenscripts/HZN/b_1_1_bird_flying_menace.txt
+++ b/forge-gui/res/tokenscripts/HZN/b_1_1_bird_flying_menace.txt
@@ -1,0 +1,8 @@
+Name:Bird Token
+ManaCost:no cost
+Colors:black
+Types:Creature Bird
+PT:1/1
+K:Flying
+K:Menace
+Oracle:Flying, menace


### PR DESCRIPTION
## Summary
- script new HZN cards like Glimpse in the Static, Griamoor, Deathless Warrior, and others
- add Bird token with flying and menace for Overcast triggers

## Testing
- `mvn -q test` *(fails: Unresolveable build extension org.apache.maven.wagon:wagon-ftp:3.5.3)*

------
https://chatgpt.com/codex/tasks/task_e_68947a5865608320b17b275ff86f3808