### PR TITLE
Add HZN custom card scripts

### DIFF
--- a/forge-gui/res/cardsfolder/HZN/adam_of_the_ironside.txt
+++ b/forge-gui/res/cardsfolder/HZN/adam_of_the_ironside.txt
@@ -1,0 +1,12 @@
+Name:Adam of the Ironside
+ManaCost:3
+Types:Legendary Artifact Creature Construct
+PT:2/2
+# First mate ability requires engine support.
+K:ETBReplacement:Other:ChooseCT
+SVar:ChooseCT:DB$ ChooseType | Type$ Creature | SpellDescription$ As CARDNAME enters, choose a creature type.
+S:Mode$ Continuous | Affected$ Card.Self | RemoveType$ Construct | AddType$ ChosenType | Description$ CARDNAME becomes the chosen type.
+S:Mode$ Continuous | Affected$ Card.Self | AddPower$ X | AddToughness$ X | References$ X | Description$ CARDNAME gets +1/+1 for each other creature you control of the chosen type.
+SVar:X:Count$Valid Creature.ChosenType+Other+YouCtrl
+Oracle:First mate—Your starting deck contains twelve or more creature cards and they all share a creature type. (If this card outside the game is your chosen first mate, you may swap it with a card in your opening hand.)\nAs CARDNAME enters, choose a creature type. CARDNAME becomes that type.\nCARDNAME gets +1/+1 for each other creature you control of the chosen type.
+# First mate ability not implemented; engine support needed.

--- a/forge-gui/res/cardsfolder/HZN/bustling_harbor.txt
+++ b/forge-gui/res/cardsfolder/HZN/bustling_harbor.txt
@@ -1,0 +1,7 @@
+Name:Bustling Harbor
+ManaCost:no cost
+Types:Land Plains Island
+R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ CARDNAME enters tapped.
+SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
+K:Cycling:2
+Oracle:({T}: Add {W} or {U}.)\nBustling Harbor enters tapped.\nCycling {2} ({2}, Discard this card: Draw a card.)

--- a/forge-gui/res/cardsfolder/HZN/clockwork_gaucho.txt
+++ b/forge-gui/res/cardsfolder/HZN/clockwork_gaucho.txt
@@ -1,0 +1,9 @@
+Name:Clockwork Gaucho
+ManaCost:2
+Types:Artifact Creature Construct Rebel
+PT:0/0
+K:etbCounter:P1P1:1
+S:Mode$ Continuous | Affected$ Creature.Artifact+Other+YouCtrl | AddPower$ X | AddToughness$ X | References$ X | Description$ Other artifact creatures you control get +1/+1 for each +1/+1 counter on CARDNAME.
+SVar:X:Count$CardCounters.P1P1
+A:AB$ PutCounter | Cost$ T | CounterType$ P1P1 | CounterNum$ 1 | SpellDescription$ Put a +1/+1 counter on CARDNAME.
+Oracle:CARDNAME enters with a +1/+1 counter on it.\nOther artifact creatures you control get +1/+1 for each +1/+1 counter on CARDNAME.\n{T}: Put a +1/+1 counter on CARDNAME.

--- a/forge-gui/res/cardsfolder/HZN/clockwork_gaucho.txt
+++ b/forge-gui/res/cardsfolder/HZN/clockwork_gaucho.txt
@@ -3,7 +3,9 @@ ManaCost:2
 Types:Artifact Creature Construct Rebel
 PT:0/0
 K:etbCounter:P1P1:1
-S:Mode$ Continuous | Affected$ Creature.Artifact+Other+YouCtrl | AddPower$ X | AddToughness$ X | References$ X | Description$ Other artifact creatures you control get +1/+1 for each +1/+1 counter on CARDNAME.
+S:Mode$ Continuous | Affected$ Creature.YouCtrl+Artifact+Other | AddPower$ X | AddToughness$ X | Description$ Other artifact creatures you control get +1/+1 for each +1/+1 counter on CARDNAME.
 SVar:X:Count$CardCounters.P1P1
 A:AB$ PutCounter | Cost$ T | CounterType$ P1P1 | CounterNum$ 1 | SpellDescription$ Put a +1/+1 counter on CARDNAME.
-Oracle:CARDNAME enters with a +1/+1 counter on it.\nOther artifact creatures you control get +1/+1 for each +1/+1 counter on CARDNAME.\n{T}: Put a +1/+1 counter on CARDNAME.
+DeckNeeds:Type$Artifact
+DeckHas:Ability$Counters
+Oracle:Clockwork Gaucho enters the battlefield with a +1/+1 counter on it.\nOther artifact creatures you control get +1/+1 for each +1/+1 counter on Clockwork Gaucho.\n{T}: Put a +1/+1 counter on Clockwork Gaucho.

--- a/forge-gui/res/cardsfolder/HZN/dreary_township.txt
+++ b/forge-gui/res/cardsfolder/HZN/dreary_township.txt
@@ -1,0 +1,7 @@
+Name:Dreary Township
+ManaCost:no cost
+Types:Land Plains Swamp
+R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ CARDNAME enters tapped.
+SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
+K:Cycling:2
+Oracle:({T}: Add {W} or {B}.)\nDreary Township enters tapped.\nCycling {2} ({2}, Discard this card: Draw a card.)

--- a/forge-gui/res/cardsfolder/HZN/galvan_ranger.txt
+++ b/forge-gui/res/cardsfolder/HZN/galvan_ranger.txt
@@ -1,0 +1,8 @@
+Name:Galvan Ranger
+ManaCost:UR UR UR
+Types:Creature Human Artificer Rogue
+PT:2/2
+K:Prowess
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Artifact.YouCtrl | TriggerZones$ Battlefield | Execute$ TrigDraw | TriggerDescription$ Whenever an artifact you control enters, you may discard a card. If you do, draw a card.
+SVar:TrigDraw:AB$ Draw | Cost$ Discard<1/Card> | NumCards$ 1
+Oracle:Prowess\nWhenever an artifact you control enters, you may discard a card. If you do, draw a card.

--- a/forge-gui/res/cardsfolder/HZN/glittering_grove.txt
+++ b/forge-gui/res/cardsfolder/HZN/glittering_grove.txt
@@ -1,0 +1,7 @@
+Name:Glittering Grove
+ManaCost:no cost
+Types:Land Mountain Forest
+R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ CARDNAME enters tapped.
+SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
+K:Cycling:2
+Oracle:({T}: Add {R} or {G}.)\nGlittering Grove enters tapped.\nCycling {2} ({2}, Discard this card: Draw a card.)

--- a/forge-gui/res/cardsfolder/HZN/monsoon_lagoon.txt
+++ b/forge-gui/res/cardsfolder/HZN/monsoon_lagoon.txt
@@ -1,0 +1,7 @@
+Name:Monsoon Lagoon
+ManaCost:no cost
+Types:Land Forest Island
+R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ CARDNAME enters tapped.
+SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
+K:Cycling:2
+Oracle:({T}: Add {G} or {U}.)\nMonsoon Lagoon enters tapped.\nCycling {2} ({2}, Discard this card: Draw a card.)

--- a/forge-gui/res/cardsfolder/HZN/plasma_enforcer.txt
+++ b/forge-gui/res/cardsfolder/HZN/plasma_enforcer.txt
@@ -4,7 +4,8 @@ Types:Artifact Creature Construct
 PT:0/0
 K:Sunburst
 A:AB$ PutCounter | Cost$ Sac<1/Artifact.Other/another artifact> | CounterType$ P1P1 | CounterNum$ 1 | SpellDescription$ Put a +1/+1 counter on CARDNAME.
-T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ When CARDNAME dies, create a 1/1 colorless Servo artifact creature token for each +1/+1 counter on it.
-SVar:TrigToken:DB$ Token | TokenAmount$ X | TokenScript$ c_1_1_a_servo | TokenOwner$ You | References$ X
+T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Battlefield | Destination$ Graveyard | Execute$ TrigToken | TriggerDescription$ When CARDNAME dies, create a 1/1 colorless Servo artifact creature token for each +1/+1 counter on CARDNAME.
+SVar:TrigToken:DB$ Token | TokenScript$ c_1_1_a_servo | TokenAmount$ X
 SVar:X:Count$CardCounters.P1P1
-Oracle:Sunburst (This enters with a +1/+1 counter on it for each color of mana spent to cast it.)\nSacrifice another artifact: Put a +1/+1 counter on CARDNAME.\nWhen CARDNAME dies, create a 1/1 colorless Servo artifact creature token for each +1/+1 counter on CARDNAME.
+DeckHas:Ability$Counters & Ability$Token
+Oracle:Sunburst (This enters the battlefield with a +1/+1 counter on it for each color of mana spent to cast it.)\nSacrifice another artifact: Put a +1/+1 counter on Plasma Enforcer.\nWhen Plasma Enforcer dies, create a 1/1 colorless Servo artifact creature token for each +1/+1 counter on Plasma Enforcer.

--- a/forge-gui/res/cardsfolder/HZN/plasma_enforcer.txt
+++ b/forge-gui/res/cardsfolder/HZN/plasma_enforcer.txt
@@ -1,0 +1,10 @@
+Name:Plasma Enforcer
+ManaCost:3
+Types:Artifact Creature Construct
+PT:0/0
+K:Sunburst
+A:AB$ PutCounter | Cost$ Sac<1/Artifact.Other/another artifact> | CounterType$ P1P1 | CounterNum$ 1 | SpellDescription$ Put a +1/+1 counter on CARDNAME.
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ When CARDNAME dies, create a 1/1 colorless Servo artifact creature token for each +1/+1 counter on it.
+SVar:TrigToken:DB$ Token | TokenAmount$ X | TokenScript$ c_1_1_a_servo | TokenOwner$ You | References$ X
+SVar:X:Count$CardCounters.P1P1
+Oracle:Sunburst (This enters with a +1/+1 counter on it for each color of mana spent to cast it.)\nSacrifice another artifact: Put a +1/+1 counter on CARDNAME.\nWhen CARDNAME dies, create a 1/1 colorless Servo artifact creature token for each +1/+1 counter on CARDNAME.

--- a/forge-gui/res/cardsfolder/HZN/scrap_the_second_myr.txt
+++ b/forge-gui/res/cardsfolder/HZN/scrap_the_second_myr.txt
@@ -1,0 +1,6 @@
+Name:Scrap, the Second Myr
+ManaCost:3
+Types:Legendary Artifact Creature Myr
+PT:2/2
+S:Mode$ Continuous | Affected$ Card.Self | EffectZone$ Battlefield | GainsAbilitiesOf$ Artifact.Creature+Other+YouCtrl | GainsAbilitiesOfZones$ Battlefield | Description$ CARDNAME has all activated abilities of other artifact creatures you control.
+Oracle:Scrap, the Second Myr has all activated abilities of other artifact creatures you control.

--- a/forge-gui/res/cardsfolder/HZN/urban_wastelands.txt
+++ b/forge-gui/res/cardsfolder/HZN/urban_wastelands.txt
@@ -1,0 +1,7 @@
+Name:Urban Wastelands
+ManaCost:no cost
+Types:Land Swamp Mountain
+R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ CARDNAME enters tapped.
+SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
+K:Cycling:2
+Oracle:({T}: Add {B} or {R}.)\nUrban Wastelands enters tapped.\nCycling {2} ({2}, Discard this card: Draw a card.)

--- a/forge-gui/res/cardsfolder/HZN/xirix_the_usurper.txt
+++ b/forge-gui/res/cardsfolder/HZN/xirix_the_usurper.txt
@@ -2,9 +2,9 @@ Name:Xirix, the Usurper
 ManaCost:1 B G U
 Types:Legendary Planeswalker Xirix
 Loyalty:4
-S:Mode$ CastWithFlash | ValidCard$ Card.Self | ValidSA$ Activated.Loyalty | Caster$ You | Condition$ IsExtraTurn | Description$ You may activate loyalty abilities of CARDNAME during extra turns any time you could cast an instant.
+S:Mode$ CastWithFlash | ValidCard$ Card.Self | ValidSA$ Activated.Loyalty | Caster$ You | Condition$ ExtraTurn | Description$ You may activate loyalty abilities of CARDNAME during extra turns any time you could cast an instant.
 A:AB$ Dig | Cost$ AddCounter<1/LOYALTY> | Planeswalker$ True | DigNum$ 3 | ChangeNum$ 1 | DestinationZone$ Hand | DestinationZone2$ Graveyard | NoReveal$ True | SpellDescription$ Look at the top three cards of your library. Put one of them into your hand and the rest into your graveyard.
-A:AB$ DestroyAll | Cost$ SubCounter<2/LOYALTY> | Planeswalker$ True | ValidCards$ Permanent.greatestCMC_NonLandPermanent+nonSelf | SpellDescription$ Destroy each nonland, non-Xirix permanent with the greatest mana value among non-Xirix permanents on the battlefield.
-A:AB$ ChangeZone | Cost$ SubCounter<6/LOYALTY> | Planeswalker$ True | ValidTgts$ Permanent | TgtPrompt$ Select target permanent card from a graveyard | Origin$ Graveyard | Destination$ Battlefield | Controller$ You | Ultimate$ True | SpellDescription$ Put target permanent card from a graveyard onto the battlefield under your control.
+A:AB$ DestroyAll | Cost$ SubCounter<2/LOYALTY> | Planeswalker$ True | ValidCards$ Permanent.nonLand+!Self+cmcEQX | SpellDescription$ Destroy each nonland, non-Xirix permanent with the greatest mana value among non-Xirix permanents on the battlefield.
+SVar:X:Count$Valid Permanent.nonLand+!Self$GreatestCMC
+A:AB$ ChangeZone | Cost$ SubCounter<6/LOYALTY> | Planeswalker$ True | ValidTgts$ Permanent | TgtPrompt$ Select target permanent card from a graveyard | Origin$ Graveyard | Destination$ Battlefield | GainControl$ True | Ultimate$ True | SpellDescription$ Put target permanent card from a graveyard onto the battlefield under your control.
 Oracle:You may activate loyalty abilities of Xirix, the Usurper during extra turns any time you could cast an instant.\n[+1]: Look at the top three cards of your library. Put one of them into your hand and the rest into your graveyard.\n[-2]: Destroy each nonland, non-Xirix permanent with the greatest mana value among non-Xirix permanents on the battlefield.\n[-6]: Put target permanent card from a graveyard onto the battlefield under your control.
-# NOTE: [-2] ability uses highest mana value among all nonland permanents; if Xirix has the highest mana value alone, no permanents are destroyed.

--- a/forge-gui/res/cardsfolder/HZN/xirix_the_usurper.txt
+++ b/forge-gui/res/cardsfolder/HZN/xirix_the_usurper.txt
@@ -1,0 +1,10 @@
+Name:Xirix, the Usurper
+ManaCost:1 B G U
+Types:Legendary Planeswalker Xirix
+Loyalty:4
+S:Mode$ CastWithFlash | ValidCard$ Card.Self | ValidSA$ Activated.Loyalty | Caster$ You | Condition$ IsExtraTurn | Description$ You may activate loyalty abilities of CARDNAME during extra turns any time you could cast an instant.
+A:AB$ Dig | Cost$ AddCounter<1/LOYALTY> | Planeswalker$ True | DigNum$ 3 | ChangeNum$ 1 | DestinationZone$ Hand | DestinationZone2$ Graveyard | NoReveal$ True | SpellDescription$ Look at the top three cards of your library. Put one of them into your hand and the rest into your graveyard.
+A:AB$ DestroyAll | Cost$ SubCounter<2/LOYALTY> | Planeswalker$ True | ValidCards$ Permanent.greatestCMC_NonLandPermanent+nonSelf | SpellDescription$ Destroy each nonland, non-Xirix permanent with the greatest mana value among non-Xirix permanents on the battlefield.
+A:AB$ ChangeZone | Cost$ SubCounter<6/LOYALTY> | Planeswalker$ True | ValidTgts$ Permanent | TgtPrompt$ Select target permanent card from a graveyard | Origin$ Graveyard | Destination$ Battlefield | Controller$ You | Ultimate$ True | SpellDescription$ Put target permanent card from a graveyard onto the battlefield under your control.
+Oracle:You may activate loyalty abilities of Xirix, the Usurper during extra turns any time you could cast an instant.\n[+1]: Look at the top three cards of your library. Put one of them into your hand and the rest into your graveyard.\n[-2]: Destroy each nonland, non-Xirix permanent with the greatest mana value among non-Xirix permanents on the battlefield.\n[-6]: Put target permanent card from a graveyard onto the battlefield under your control.
+# NOTE: [-2] ability uses highest mana value among all nonland permanents; if Xirix has the highest mana value alone, no permanents are destroyed.

--- a/forge-gui/res/cardsfolder/HZN/zarad_the_final_adversary.txt
+++ b/forge-gui/res/cardsfolder/HZN/zarad_the_final_adversary.txt
@@ -1,0 +1,10 @@
+Name:Zarad, the Final Adversary
+ManaCost:7 W B
+Types:Legendary Creature Human Horror
+PT:7/5
+S:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ X | EffectZone$ All | Description$ This spell costs {1} less to cast for each creature that died this turn.
+SVar:X:Count$ThisTurnEntered_Graveyard_from_Battlefield_Creature
+T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigReanimate | TriggerDescription$ At the beginning of your upkeep, put target creature card from a graveyard onto the battlefield under your control.
+SVar:TrigReanimate:DB$ ChangeZone | Origin$ Graveyard | Destination$ Battlefield | ValidTgts$ Creature | TgtPrompt$ Select target creature card from a graveyard | Controller$ You
+A:AB$ Pump | Cost$ 1 Sac<1/Creature.Other/another creature> | Defined$ Self | KW$ Indestructible | SpellDescription$ CARDNAME gains indestructible until end of turn.
+Oracle:This spell costs {1} less to cast for each creature that died this turn.\nAt the beginning of your upkeep, put target creature card from a graveyard onto the battlefield under your control.\n{1}, Sacrifice another creature: Zarad, the Final Adversary gains indestructible until end of turn.

--- a/forge-gui/res/cardsfolder/HZN/zarad_the_final_adversary.txt
+++ b/forge-gui/res/cardsfolder/HZN/zarad_the_final_adversary.txt
@@ -5,6 +5,6 @@ PT:7/5
 S:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ X | EffectZone$ All | Description$ This spell costs {1} less to cast for each creature that died this turn.
 SVar:X:Count$ThisTurnEntered_Graveyard_from_Battlefield_Creature
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigReanimate | TriggerDescription$ At the beginning of your upkeep, put target creature card from a graveyard onto the battlefield under your control.
-SVar:TrigReanimate:DB$ ChangeZone | Origin$ Graveyard | Destination$ Battlefield | ValidTgts$ Creature | TgtPrompt$ Select target creature card from a graveyard | Controller$ You
+SVar:TrigReanimate:DB$ ChangeZone | Origin$ Graveyard | Destination$ Battlefield | ValidTgts$ Creature | TgtPrompt$ Select target creature card from a graveyard | GainControl$ True
 A:AB$ Pump | Cost$ 1 Sac<1/Creature.Other/another creature> | Defined$ Self | KW$ Indestructible | SpellDescription$ CARDNAME gains indestructible until end of turn.
 Oracle:This spell costs {1} less to cast for each creature that died this turn.\nAt the beginning of your upkeep, put target creature card from a graveyard onto the battlefield under your control.\n{1}, Sacrifice another creature: Zarad, the Final Adversary gains indestructible until end of turn.


### PR DESCRIPTION
## Summary
- add Xirix planeswalker with instant-speed extra turn activations and graveyard reanimation
- script Zarad, Galvan Ranger, Adam of the Ironside, Clockwork Gaucho, Plasma Enforcer, and Scrap, the Second Myr
- include dual land cycle with cycling {2}

## Testing
- `mvn -q test` *(fails: Unresolveable build extension org.apache.maven.wagon:wagon-ftp:3.5.3)*

------
https://chatgpt.com/codex/tasks/task_e_689483150800832096673ebbfbcbedd0