### PR TITLE
Allow custom cards in Adventure rewards

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/data/RewardData.java
+++ b/forge-gui-mobile/src/forge/adventure/data/RewardData.java
@@ -114,8 +114,6 @@ public class RewardData implements Serializable {
                     return false;
             } else if(Arrays.asList(configData.restrictedEditions).contains(input.getEdition()))
                 return false;
-            if(input.getRules().isCustom())
-                return false;
             return !Arrays.asList(configData.restrictedCards).contains(input.getName());
         });
         //Filter AI cards for enemies.

--- a/forge-gui-mobile/src/forge/adventure/util/AdventureEventController.java
+++ b/forge-gui-mobile/src/forge/adventure/util/AdventureEventController.java
@@ -8,12 +8,18 @@ import forge.adventure.pointofintrest.PointOfInterestChanges;
 import forge.deck.Deck;
 import forge.item.BoosterPack;
 import forge.item.PaperCard;
+import forge.item.PaperCardPredicates;
 import forge.item.SealedTemplate;
 import forge.item.generation.BoosterGenerator;
 import forge.item.generation.UnOpenedProduct;
+import forge.card.CardEdition;
+import forge.card.CardRarity;
 import forge.model.CardBlock;
 import forge.model.FModel;
 import forge.util.Aggregates;
+import forge.util.MyRandom;
+import java.util.stream.Collectors;
+import java.util.function.Predicate;
 
 import java.io.Serializable;
 import java.time.LocalDate;
@@ -131,10 +137,33 @@ public class AdventureEventController implements Serializable {
     }
 
     public Deck generateBooster(String setCode) {
+        CardEdition edition = FModel.getMagicDb().getEditions().get(setCode);
         List<PaperCard> cards = BoosterGenerator.getBoosterPack(StaticData.instance().getBoosters().get(setCode));
+        if (edition != null) {
+            Predicate<PaperCard> inSet = PaperCardPredicates.printedInSet(setCode);
+            if (cards.stream().anyMatch(inSet.negate())) {
+                List<PaperCard> pool = StaticData.instance().getCommonCards().streamAllCards()
+                        .filter(inSet)
+                        .collect(Collectors.toList());
+                Map<CardRarity, List<PaperCard>> byRarity = pool.stream()
+                        .collect(Collectors.groupingBy(PaperCard::getRarity));
+                for (int i = 0; i < cards.size(); i++) {
+                    PaperCard card = cards.get(i);
+                    if (!inSet.test(card)) {
+                        List<PaperCard> candidates = byRarity.get(card.getRarity());
+                        if (candidates == null || candidates.isEmpty()) {
+                            candidates = pool;
+                        }
+                        if (!candidates.isEmpty()) {
+                            cards.set(i, Aggregates.random(candidates));
+                        }
+                    }
+                }
+            }
+        }
         Deck output = new Deck();
         output.getMain().add(cards);
-        String editionName = FModel.getMagicDb().getEditions().get(setCode).getName();
+        String editionName = edition != null ? edition.getName() : setCode;
         output.setName(editionName + " Booster");
         output.setComment(setCode);
         return output;


### PR DESCRIPTION
## Summary
- let Adventure mode include user-made custom cards
- ensure custom boosters only pull cards from their edition
- keep rarity mix of custom boosters when replacing off-set cards

## Testing
- `mvn -q -pl forge-gui-mobile -am test` *(fails: Unresolveable build extension: Plugin org.apache.maven.wagon:wagon-ftp:3.5.3 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_686b2596be3c8320ad81ff2d27e6b92f